### PR TITLE
fix: windows config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ This extension contributes the following settings:
 
 * `goose.enable`: enable/disable this extension
 
+## Configuration File Location
+
+Goose's CLI and this extension look for a configuration file containing
+`GOOSE_PROVIDER` and `GOOSE_MODEL` values. The default locations are:
+
+* **Linux/macOS:** `~/.config/goose/config.yaml`
+* **Windows:** `%APPDATA%\Block\goose\config\config.yaml` (e.g. `C:\Users\<you>\AppData\Roaming\Block\goose\config\config.yaml`)
+
+Ensure this file exists and is populated with valid values before starting the extension.
+
 ----
 
 ## Support

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,7 +8,7 @@ For architectural details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
 1. Clone the repository
 2. Navigate to the project root directory
-3. Install dependencies: `npm install`
+3. Install dependencies: `npm install` (this installs devDependencies like `rimraf` used by build and test scripts)
 4. Install webview dependencies: `cd webview-ui && npm install && cd ..`
 5. Build the extension and webview: `npm run compile`
 6. Open the project root in VSCode: `code .`

--- a/src/utils/configReader.ts
+++ b/src/utils/configReader.ts
@@ -38,13 +38,10 @@ export function getConfigPath(os: OS = osDefault): string | null {
 
     switch (os.platform()) {
         case 'win32':
-            // Windows path: ~\AppData\Roaming\Block\goose\config\config.yaml
-            const appData = process.env.APPDATA;
-            if (!appData) {
-                logger.error('Could not determine APPDATA directory on Windows.');
-                return null; // Return null if APPDATA is not set
-            }
-            // Use appData instead of homeDir for the base path on Windows
+            // Windows path: %APPDATA%\Block\goose\config\config.yaml
+            // Fallback to the typical Roaming path if APPDATA is undefined
+            const appData = process.env.APPDATA ||
+                path.join(homeDir, 'AppData', 'Roaming');
             configPath = path.join(appData, 'Block', 'goose', 'config', 'config.yaml');
             break;
         case 'darwin': // macOS


### PR DESCRIPTION
Based on [Goose's doc](https://github.com/block/goose/blob/main/documentation/docs/guides/config-file.md?plain=1#L12), for Windows, the config file should be located at: 
* Windows: `%APPDATA%\Block\goose\config\config.yaml`

----
🤞 fixes #7 