### PR TITLE
fix: add debian binary path

### DIFF
--- a/src/utils/binaryPath.ts
+++ b/src/utils/binaryPath.ts
@@ -67,6 +67,7 @@ export function getBinaryPath(_context: ExtensionContext, binaryName: string): s
             '/opt/Goose/resources/app/bin', // Common install location
             '/opt/Goose/resources/bin',
             '/opt/Goose/resources/app.asar.unpacked/bin',
+            '/usr/lib/goose/resources/bin', // .deb install location
             '/usr/local/Goose/resources/app/bin',
             '/usr/local/Goose/resources/bin',
             '/usr/local/bin', // Global bin where the goosed might be symlinked


### PR DESCRIPTION
This PR adds the linux binary path `/usr/lib/goose/resources/bin` which is the location of `goosed` when installed from a *.deb file. it seems like this will fix the debian flavor of #17 