### PR TITLE
refactor(binaryPath): use/prioritize user-defined binary path when found

### DIFF
--- a/src/utils/binaryPath.ts
+++ b/src/utils/binaryPath.ts
@@ -21,10 +21,18 @@ export function getBinaryPath(_context: ExtensionContext, binaryName: string): s
 
     // On Windows, use .exe suffix
     const executableName = platform === 'win32' ? `${binaryName}.exe` : binaryName;
-
+    
     // Define potential base paths for the Goose Desktop installation
     const basePaths: string[] = [];
-
+    
+    // check for a user-defined binary path and push to the top of the directory list if found
+    const userBinaryPath = vscode.workspace.getConfiguration('goose.server').get<string>('path');
+    if (userBinaryPath && userBinaryPath.trim().length > 0) {
+        const normalizedPath = path.normalize(userBinaryPath);
+        logger.info(`User-defined binary path found: ${normalizedPath}`);
+        basePaths.push(normalizedPath);
+    }
+    
     if (platform === 'darwin') { // macOS
         // Check multiple potential paths for macOS - Electron apps can have different structures
         const macAppPaths = [


### PR DESCRIPTION
This PR picks up the user-defined binary path set at `goose.server.path` and makes it the first element of the directory search list. If it does contain a goosed, it will be found first. 

This change would benefit from a test on Windows which I don't have access to.