### PR TITLE
fix: stop treating long session/prompt streams as cancelled (#33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ bun.lockb
 .rp1/*
 !.rp1/context/
 !.rp1/context/**
+.rp1/context/meta.json

--- a/.rp1/context/architecture.md
+++ b/.rp1/context/architecture.md
@@ -1,187 +1,218 @@
+---
+scope: kbRoot
+path_pattern: "architecture.md"
+producer: knowledge-base
+type: document
+description: "System architecture with diagrams, component relationships, data flows, security, and deployment for a single-project codebase."
+strictness: strict
+---
 # System Architecture
 
-**Project**: VS Code Goose
-**Architecture Pattern**: Bridge/Adapter with Message-Driven Communication
-**Last Updated**: 2025-12-21
+**Project**: vscode-goose
+**Architecture Pattern**: Layered, message-driven thin UI bridge
+**Last Updated**: 2026-04-23
 
 ## High-Level Architecture
 
 ```mermaid
 graph TB
-    subgraph VSCode["VS Code"]
-        UI["VS Code UI<br/>(Commands, Activity Bar)"]
-        ExtHost["Extension Host<br/>(Node.js)"]
-        Webview["Chat Webview<br/>(React/iframe)"]
+    subgraph VSCode["VS Code Host"]
+        UI["UI: Activity Bar / Editor / Commands"]
+        Webview["Sandboxed Webview (React iframe)"]
+        GState["globalState"]
     end
 
-    subgraph Extension["Extension Host Components"]
-        ExtMain["extension.ts<br/>(Main Entry)"]
-        SubMgr["SubprocessManager<br/>(Process Lifecycle)"]
-        JsonRpc["JsonRpcClient<br/>(ACP Protocol)"]
-        SessMgr["SessionManager<br/>(Session State)"]
-        WebProv["WebviewProvider<br/>(UI Bridge)"]
-        VC["VersionChecker"]
-        FSS["FileSearchService"]
+    subgraph Extension["src/extension/"]
+        Ext["extension.ts activate()"]
+        Cmd["commands.ts"]
+        Cfg["config.ts"]
+        Disc["binaryDiscovery.ts"]
+        Ver["versionChecker.ts (>=1.16.0)"]
+        Sub["subprocessManager.ts"]
+        Rpc["jsonRpcClient.ts (ndjson)"]
+        Sess["sessionManager.ts"]
+        Store["sessionStorage.ts"]
+        WvP["webviewProvider.ts"]
+        FSS["fileSearchService.ts"]
     end
 
-    subgraph External["External"]
-        goose["goose Process<br/>(AI Daemon)"]
-        GS["globalState"]
+    subgraph Shared["src/shared/"]
+        Msgs["messages.ts (24 types)"]
+        Errs["errors.ts (fp-ts)"]
     end
 
-    UI -->|commands| ExtMain
-    ExtMain --> SubMgr
-    ExtMain --> SessMgr
-    ExtMain --> WebProv
-    SubMgr -->|spawn/stdin/stdout| goose
-    SubMgr --> JsonRpc
-    JsonRpc -->|JSON-RPC 2.0| goose
-    goose -->|stream notifications| JsonRpc
-    WebProv <-->|postMessage| Webview
-    SessMgr --> JsonRpc
-    SessMgr -->|persist| GS
-    VC -->|goose --version| goose
-    FSS -->|workspace.findFiles| UI
+    subgraph WV["src/webview/"]
+        App["App.tsx"]
+        Bridge["bridge.ts"]
+        Hooks["hooks: useChat, useFilePicker, useContextChips"]
+    end
+
+    Goose[["goose subprocess (ACP agent)"]]
+
+    subgraph CI["GitHub Actions"]
+        PRW["pr-checks.yml"]
+        MainW["ci.yml"]
+        RP["release-please"]
+        VSCE["vsce package --no-deps"]
+        MP["VS Code Marketplace"]
+    end
+
+    UI --> Ext
+    Ext --> Cmd
+    Ext --> Cfg
+    Ext --> WvP
+    Ext --> Sess
+    Cmd --> WvP
+    Cmd --> FSS
+    WvP <--> Webview
+    Webview --> App
+    App --> Bridge
+    App --> Hooks
+    Bridge -.-> Msgs
+
+    Ext --> Disc --> Ver --> Sub
+    Sub --> Goose
+    Sub --> Rpc
+    Rpc <--> Goose
+    Sess --> Rpc
+    Sess --> Store --> GState
+    FSS --> UI
+
+    MainW --> RP --> VSCE --> MP
+    PRW -.-> MainW
 ```
 
-## Architectural Patterns
+## Patterns
 
-### Bridge/Adapter Architecture
-
-The extension is deliberately minimal - a thin UI layer connecting VS Code webview to Goose backend via Agent Communication Protocol (ACP). No business logic in the extension itself.
-
-### Layered Architecture
-
-Four distinct layers with unidirectional dependencies:
-
-1. **Webview** (presentation) - React components
-2. **Extension** (orchestration) - VS Code integration
-3. **ACP Client** (protocol) - JSON-RPC handling
-4. **Goose subprocess** - External process communication
-
-### Message-Driven Communication
-
-All communication between webview and extension uses a strongly-typed message passing system with 24 message types, factory functions, and type guards.
-
-### Gated Activation
-
-Multi-stage activation gate: binary discovery → version validation → subprocess spawn. Each stage can block activation with appropriate user messaging.
+- **Bridge / Adapter (thin UI)** — Extension is a pure orchestration layer translating VS Code events to/from an external Goose subprocess via ACP. All AI behavior lives in goose. Evidence: `AGENTS.md`, `src/extension/extension.ts`.
+- **Layered Architecture** — Four layers: Webview (React/iframe), Extension host (VS Code integration), ACP client (JSON-RPC), Goose subprocess. Dependencies flow downward only. Evidence: `src/{extension,webview,shared}/`.
+- **Message-Driven Communication** — Strongly-typed `postMessage` contract with ~24 `WebviewMessage` variants, factories, and guards. Evidence: `src/shared/messages.ts`, `src/webview/bridge.ts`.
+- **Gated Activation** — Multi-stage: binary discovery → version validation (>= 1.16.0) → subprocess spawn → ACP `initialize`. Each stage can block UI with actionable status. Evidence: `binaryDiscovery.ts`, `versionChecker.ts`, `subprocessManager.ts`.
+- **Typed Async Error Handling (fp-ts)** — `Either`/`TaskEither` for recoverable async failures instead of thrown exceptions. Evidence: `src/shared/errors.ts`, `package.json` (fp-ts `^2.16.0`).
+- **Sandboxed Webview with Ready-Sync Queue** — Ready handshake + queued outbox so extension-originated events are not dropped before the React app mounts. Evidence: `src/extension/webviewProvider.ts`.
+- **Conventional Commits + release-please automation** — Every push to main runs release-please; merging the Release PR auto-tags `vscode-v*`, builds VSIX with `vsce --no-dependencies`, publishes to Marketplace. Evidence: `commitlint.config.js`, `.husky/*`, `release-please-config.json`, `.github/workflows/ci.yml`.
 
 ## Component Architecture
 
-### Extension Host Layer
-
-**Location**: `src/extension/`
-**Components**:
-
-- `extension.ts` - Orchestrates activation, ACP session init, wires components
-- `sessionManager.ts` - Session lifecycle, history replay, ACP coordination
-- `webviewProvider.ts` - Webview lifecycle, message queue, ready sync
-- `subprocessManager.ts` - Spawns goose binary, manages lifecycle events
-- `jsonRpcClient.ts` - JSON-RPC 2.0 client with ndjson framing
-- `versionChecker.ts` - Binary version validation (>= 1.16.0)
-- `fileSearchService.ts` - Workspace file discovery for @ picker
-- `commands.ts` - VS Code command registration (showLogs, restart, sendSelectionToChat)
-
-### Webview Layer
-
+### Webview (Presentation)
+**Purpose**: Sandboxed React UI for chat, context chips, @ file picker.
 **Location**: `src/webview/`
-**Components**:
+**Components**: `App.tsx`, `bridge.ts`, `components/*`, `hooks/*`.
+**Dependencies (internal)**: Shared (messages/types).
 
-- `App.tsx` - Root component with status, session and chat state
-- `bridge.ts` - postMessage abstraction for extension communication
-- `ChatView.tsx` - Chat container with keyboard navigation
-- `InputArea.tsx` - Input with chips, file picker integration
-- `useChat.ts` - Reducer-based chat state management
-- `useContextChips.ts` - Chip state management
-- `useFilePicker.ts` - @ mention detection and search
-
-### Shared Layer
-
+### Shared Contracts
+**Purpose**: Cross-boundary type contracts compiled into both bundles.
 **Location**: `src/shared/`
-**Components**:
+**Components**: `messages.ts`, `types.ts`, `errors.ts`, `contextTypes.ts`, `sessionTypes.ts`, `fileReferenceParser.ts`.
 
-- `messages.ts` - 24 WebviewMessage types, payloads, factories, guards
-- `types.ts` - ProcessStatus, ChatMessage, MessageContext
-- `errors.ts` - GooseError discriminated union, factory functions
-- `contextTypes.ts` - ContextChip, FileSearchResult
-- `fileReferenceParser.ts` - Parse file references from markdown
+### Extension Host (Orchestration)
+**Purpose**: VS Code integration, activation gate, webview lifecycle, session state.
+**Location**: `src/extension/`
+**Components**: `extension.ts`, `commands.ts`, `config.ts`, `logger.ts`, `sessionManager.ts`, `sessionStorage.ts`, `webviewProvider.ts`, `fileSearchService.ts`.
+**Dependencies**: Shared, ACP Client.
 
-## Key Data Flows
+### ACP Client (Protocol)
+**Purpose**: JSON-RPC 2.0 over ndjson; subprocess + binary discovery + version gate.
+**Location**: `src/extension/`
+**Components**: `jsonRpcClient.ts`, `subprocessManager.ts`, `binaryDiscovery.ts`, `versionChecker.ts`.
+**Dependencies**: goose subprocess.
 
-### User Chat Message Flow
+### Goose Subprocess (External)
+**Purpose**: AI agent daemon speaking ACP over stdin/stdout; owns all model/tool behavior.
+**Components**: goose binary (>= 1.16.0), out-of-tree.
 
+## Data Flow
+
+### Version-Gated Activation
+1. VS Code fires `onStartupFinished`.
+2. `extension.ts activate()` constructs logger, config, webviewProvider.
+3. `binaryDiscovery.ts` resolves the goose binary (config override or PATH lookup).
+4. `versionChecker.ts` spawns `goose --version` and validates `>= 1.16.0`.
+5. `subprocessManager.ts` spawns the long-lived goose ACP process.
+6. `jsonRpcClient.ts` sends `initialize` and registers a notification handler.
+7. `sessionManager.ts` calls `session/new` or `session/load` and hydrates the webview.
+
+### Chat Prompt Streaming
 ```mermaid
 sequenceDiagram
     participant User
     participant Webview
     participant Extension
-    participant JsonRpc
-    participant goose
-
-    User->>Webview: Type message + Enter
+    participant Rpc as JsonRpcClient
+    participant Goose
+    User->>Webview: Enter / Send
     Webview->>Extension: SEND_MESSAGE
-    Extension->>Extension: Build ACP content blocks
-    Extension->>JsonRpc: session/prompt request
-    JsonRpc->>goose: JSON-RPC via stdin
-
-    loop Streaming Response
-        goose-->>JsonRpc: session/update notification
-        JsonRpc-->>Extension: onNotification callback
-        Extension-->>Webview: STREAM_TOKEN
-        Webview-->>User: Render markdown chunk
-    end
-
+    Extension->>Rpc: session/prompt (text + resource_link[])
+    Rpc->>Goose: JSON-RPC ndjson
+    Goose-->>Rpc: session/update agent_message_chunk*
+    Rpc-->>Extension: forward chunks
+    Extension-->>Webview: STREAM_TOKEN*
+    Goose-->>Rpc: session/prompt result
     Extension-->>Webview: GENERATION_COMPLETE
 ```
 
-### Send Selection to Goose (Cmd+Shift+G)
+### Send Selection to Goose (Cmd/Ctrl+Shift+G)
+1. Keybinding or `editor/context` menu triggers `goose.sendSelectionToChat`.
+2. `commands.ts` captures selection + file URI + line range.
+3. Reveals `goose.chatView`, waits for the webview ready signal.
+4. Posts `ADD_CONTEXT_CHIP` with file/range metadata.
+5. Webview renders the chip; next user prompt serializes it as a `resource_link` block.
 
-1. User selects code and presses Cmd+Shift+G
-2. `registerContextCommands` handler triggered
-3. `goose.chatView.focus` reveals panel
-4. `waitForReady()` ensures webview initialized
-5. `createAddContextChipMessage()` sent with file/range
-6. Webview displays chip and awaits user prompt
+### File Search (@ mention)
+1. Webview detects `@` at a word boundary in the input.
+2. Webview sends `FILE_SEARCH` with the query.
+3. `fileSearchService.ts` calls `workspace.findFiles` with recent-score sort.
+4. Extension returns `SEARCH_RESULTS`.
+5. Webview renders the picker and emits a chip on selection.
 
-### File Search (@ Picker)
-
-1. User types @ in chat input
-2. `detectAtTrigger()` scans backwards for @ at word boundary
-3. Webview sends FILE_SEARCH message with query
-4. `fileSearchService.search()` uses `vscode.workspace.findFiles()`
-5. Results sorted by recentScore
-6. SEARCH_RESULTS message sent back
-7. FilePicker dropdown displayed
-
-### Version-Gated Activation
-
-1. `discoverBinary()` locates goose binary
-2. `checkVersion()` spawns `goose --version`
-3. `meetsMinimumVersion()` validates >= 1.16.0
-4. If version fails: `updateVersionStatus()` blocks UI
-5. If version passes: spawn subprocess
+### Release & Publish
+1. Commits land on `main` with Conventional Commit prefixes.
+2. `.github/workflows/ci.yml` runs release-please on push.
+3. release-please opens/updates a Release PR bumping `package.json` and the manifest.
+4. Merging the Release PR tags `vscode-v<version>` and triggers the release job.
+5. Job runs `bun install --frozen-lockfile`, `bun run build`.
+6. Job runs `vsce package --no-yarn --no-dependencies -o dist/vscode-goose-<v>.vsix`.
+7. `gh release upload` attaches VSIX; `vsce publish --packagePath` ships to the Marketplace when `VSCE_PAT` is set.
 
 ## Integration Points
 
-### Goose ACP Subprocess
+### External Services
+- **Goose ACP Subprocess** — external AI agent; JSON-RPC 2.0 over stdin/stdout (ndjson). Methods: `initialize`, `session/{new,load,prompt,cancel}`. Notification: `session/update`. Min version 1.16.0. Context chips → `resource_link` blocks. Spec: agentclientprotocol.com.
+- **VS Code Extension API** — in-process host (engines `^1.95.0`). Contributes: viewsContainer `goose`, view `goose.chatView`, commands (`showLogs`, `restart`, `sendSelectionToChat`), `editor/context` menu, keybinding Cmd/Ctrl+Shift+G. Settings: `goose.binaryPath`, `goose.logLevel`. `workspace.findFiles` for @ picker.
+- **GitHub Actions CI** — two workflows. `ci.yml`: release-please + lint/test/build on push to `main`. `pr-checks.yml`: lint/test/build on PR. Both use `oven-sh/setup-bun@v2` with frozen lockfile. Release job adds `actions/setup-node@v4` for `vsce`.
+- **release-please** — `googleapis/release-please-action@v4`. Config: `release-please-config.json` with `tag-separator vscode-v`, `include-component-in-tag=false`, `extra-files=['package.json']`, `bootstrap-sha` pinned. Manifest: `.release-please-manifest.json` tracks `.` at `0.2.1`. Uses `RELEASE_PLEASE_PAT`.
+- **VS Code Marketplace** — public distribution. Publisher `block`. Packaging `vsce package --no-dependencies` (deps bundled by Bun). Publish gated on `VSCE_PAT`.
+- **Husky + commitlint** — `.husky/pre-commit` + `.husky/commit-msg` installed by `prepare: 'husky'`. `commitlint.config.js` uses `@commitlint/config-conventional` — required for release-please bump detection.
+- **Biome** — lint + format (single-tool replacement). Invoked via `bunx biome`. `biome.json` ignores `node_modules`, `dist`, `out`, `.vscode-test`, `*.vsix`, `package-lock.json`, `bun.lockb`, and `package.json`.
 
-- **Protocol**: JSON-RPC 2.0 over stdin/stdout (ndjson framing)
-- **Methods**: `initialize`, `session/new`, `session/load`, `session/prompt`
-- **Notifications**: `session/cancel`, `session/update`
-- **Version Requirement**: >= 1.16.0
+### Internal Communication
+- **Extension ↔ Webview**: typed `postMessage` discriminated-union over shared contract in `src/shared/messages.ts`.
+- **Extension ↔ Goose**: JSON-RPC 2.0 with ndjson framing over spawned subprocess stdio.
 
-### VS Code APIs
+## Data Flow Summary
 
-- **Workspace**: `findFiles()` for @ picker
-- **Commands**: `goose.showLogs`, `goose.restart`, `goose.sendSelectionToChat`
-- **Keybindings**: Cmd+Shift+G for sendSelectionToChat
-- **Context Menus**: editor/context menu integration
+**State Management**
+- Extension: in-memory `SessionManager` mirrored to VS Code `globalState` via `src/extension/sessionStorage.ts`.
+- Webview: transient UI state in React hooks (`useChat`, `useContextChips`, `useFilePicker`).
+- Conversation history: owned by goose; surfaced via `session/load` replay.
 
-## Deployment
+**Primary data flows**
+- **User chat turn**: keystrokes → bridge `postMessage` → extension builds ACP blocks → `session/prompt` → `session/update` stream → `STREAM_TOKEN` → rendered markdown.
+- **Session restore**: stored session id → `sessionManager.loadSession` → `session/load` → history replay.
+- **Release artifact**: Conventional Commits → release-please Release PR → merge tags `vscode-v<v>` → bun build → VSIX → GitHub Release + Marketplace.
 
-- **Distribution**: VS Code Marketplace via VSIX
-- **Build**: Bun bundler, Webpack, Tailwind CSS v4
-- **Linting**: Biome for formatting and linting
-- **Webview Options**: `retainContextWhenHidden: true`
-- **Version Gate**: Checks goose >= 1.16.0 before subprocess spawn
+## Security Architecture
+
+- **Webview CSP**: `getWebviewContent` sets `default-src 'none'; script-src 'nonce-…'`; `localResourceRoots` restricted to `dist/webview`.
+- **No remote assets**: all scripts/styles served from the extension bundle.
+- **External links**: anchors in `MarkdownRenderer` post `OPEN_EXTERNAL_LINK`; VS Code `env.openExternal` enforces user confirmation where configured.
+- **Minimum version gate**: fail-closed activation blocks any ACP interaction if the goose binary is missing or below 1.16.0.
+
+## Deployment Architecture
+
+- **Type**: VS Code Extension (VSIX).
+- **Environment**: VS Code engines `^1.95.0` on the user's machine; spawns the local goose binary as a child process.
+- **Distribution**: VS Code Marketplace (publisher `block`) + GitHub Releases with tag prefix `vscode-v`, driven by release-please.
+- **Build toolchain**: Bun bundler for both extension (CJS, node target, `vscode` external) and webview (minified IIFE); Tailwind CSS v4 via `@tailwindcss/cli`; TypeScript for type-checking only.
+- **Packaging**: `vsce package --no-dependencies` — relies on bundled `dist/*`. `.vscodeignore` whitelists `dist/extension.js(.map)`, `dist/webview/**`, `resources/**`, `package.json`, `README.md`, `LICENSE`; excludes `src/`, `node_modules/`, `docs/`, `.rp1/`, `biome.json`, lockfiles, `*.test.ts`.
+- **CI**: `ci.yml` (main + release) and `pr-checks.yml` (PR) using `oven-sh/setup-bun@v2` with frozen-lockfile installs.

--- a/.rp1/context/concept_map.md
+++ b/.rp1/context/concept_map.md
@@ -1,154 +1,146 @@
+---
+scope: kbRoot
+path_pattern: "concept_map.md"
+producer: knowledge-base
+type: document
+description: "Domain concepts, terminology glossary, and cross-references for a single-project codebase."
+strictness: strict
+---
 # Domain Concepts & Terminology
 
-**Project**: VS Code Goose
-**Domain**: AI Agent Communication, VS Code Extension Development, Session Management
+**Project**: vscode-goose
+**Domain**: VS Code extension — thin UI bridge over ACP (Agent Communication Protocol) to the Goose AI agent subprocess
 
 ## Core Business Concepts
 
 ### ProcessStatus
-**Definition**: State machine enum for goose subprocess lifecycle: STOPPED → STARTING → RUNNING → ERROR. Tracks the current operational state of the external goose binary process.
+**Definition**: State machine for the goose subprocess lifecycle: `STOPPED -> STARTING -> RUNNING -> ERROR`. Drives UI status indicators and gates operations.
 **Implementation**: `src/shared/types.ts`
-**Values**:
-- `STOPPED`: Process not running
-- `STARTING`: Process spawn initiated
-- `RUNNING`: Process active and communicating
-- `ERROR`: Process crashed or failed to start
 
 ### ChatMessage
-**Definition**: Core data structure representing a single message in the chat conversation. Contains id, role (user/assistant/error), content, timestamp, status, and optional context attachments.
+**Definition**: Single chat message. Fields: id, role, content, timestamp (optional for history), status, originalContent (for retry), context (attached file refs).
 **Implementation**: `src/shared/types.ts`
-**Key Properties**:
-- `id`: Unique identifier for message correlation
-- `role`: MessageRole enum (USER, ASSISTANT, ERROR)
-- `content`: Text content of the message
-- `timestamp`: When the message was created (optional for history messages)
-- `status`: MessageStatus tracking lifecycle state
-- `originalContent`: For error messages, stores original message for retry
-- `context`: Optional array of MessageContext for attached file references
 
-**Business Rules**:
-- User messages are always status=COMPLETE
-- Assistant messages transition: PENDING → STREAMING → COMPLETE/CANCELLED/ERROR
-- Error messages may have originalContent to enable retry functionality
-
-### ContextChip
-**Definition**: UI element representing a file or code selection reference attached to a chat message. Displayed as removable pills in the input area.
-**Implementation**: `src/shared/contextTypes.ts`, `src/webview/hooks/useContextChips.ts`
-**Key Properties**:
-- `id`: Unique identifier for the chip
-- `filePath`: Absolute path to the referenced file
-- `fileName`: Display name extracted from path
-- `languageId`: VS Code language identifier for syntax highlighting
-- `lineRange`: Optional line range (startLine, endLine) for code selections
-
-**Business Rules**:
-- Chips are displayed as removable pills in the input area
-- Duplicate detection prevents same file/range being added twice
-- Keyboard navigation (arrow keys, backspace) for accessibility
-
-### MessageContext
-**Definition**: Attached file reference within a ChatMessage. Contains filePath, fileName, optional line range, and optional content for history replay.
+### MessageRole / MessageStatus / LogLevel
+**Definition**:
+- `MessageRole`: `USER | ASSISTANT | ERROR` — ERROR marks a message whose delivery/generation failed.
+- `MessageStatus`: `PENDING -> STREAMING -> COMPLETE | CANCELLED | ERROR`. User messages are always COMPLETE; assistant messages transition through streaming.
+- `LogLevel`: numeric severity (`DEBUG=0, INFO=1, WARN=2, ERROR=3`) parsed from `goose.logLevel`.
 **Implementation**: `src/shared/types.ts`
-**Relationships**:
-- Converts from ContextChip when message is sent
-- Contains `content` field for history messages (from ACP embedded resource)
-- Absent content for live messages (extension reads on demand)
+
+### ChatState
+**Definition**: Webview UI bundle: `messages[]`, `isGenerating`, `currentResponseId`, `inputDraft`, `focusedMessageIndex`.
+**Implementation**: `src/shared/types.ts`
+
+### MessageContext / ContextChip
+**Definition**:
+- `MessageContext`: attached file reference inside a ChatMessage (`filePath`, `fileName`, optional `range`, optional `content` — content is present only when history is replayed via ACP embedded resource).
+- `ContextChip`: input-area UI pill representing a file or code-range reference attached to the next prompt (`id`, `filePath`, `fileName`, `languageId`, optional `range`).
+**Implementation**: `src/shared/contextTypes.ts`, `src/shared/types.ts`
 
 ### FileSearchResult
-**Definition**: Search result from @ file picker. Used for selecting files to attach as context.
+**Definition**: Result row from the @-picker file search (`path`, `fileName`, `relativePath`, `languageId`, `recentScore` — timestamp-based ranking).
 **Implementation**: `src/shared/contextTypes.ts`
-**Key Properties**:
-- `path`: Absolute file path
-- `fileName`: File name for display
-- `relativePath`: Path relative to workspace root
-- `languageId`: Language identifier for icon display
-- `recentScore`: Timestamp-based ranking for recently accessed files
 
-### ParsedFileReference
-**Definition**: Extracted file reference from markdown content sent by Goose. Used for rendering file content blocks as collapsible cards.
+### ParsedFileReference / ParseResult
+**Definition**: `ParsedFileReference` is a parsed file-reference block extracted from assistant markdown (H1 `# /path` or `File: /path:start-end` followed by a fenced code block). `ParseResult` is the discriminated union `{ type: 'file_reference', reference } | { type: 'text', content }` used to switch rendering between FileCard and Markdown.
 **Implementation**: `src/shared/fileReferenceParser.ts`
-**Key Properties**:
-- `filePath`: Extracted absolute file path
-- `fileName`: File name from path
-- `content`: Optional file content from code block
-- `language`: Language hint from code fence
-- `lineRange`: Optional line range for selections
 
-### SessionEntry
-**Definition**: Stored session metadata containing sessionId, title, cwd (working directory), and createdAt timestamp. Represents a persisted conversation session that can be resumed.
-**Implementation**: `src/shared/sessionTypes.ts`
+### SessionEntry / SessionStorageData / GroupedSessions
+**Definition**:
+- `SessionEntry`: locally-persisted session metadata — `sessionId`, `title`, `cwd`, `createdAt`. Intentionally minimal; full transcript lives in goose.
+- `SessionStorageData`: versioned wrapper — `schemaVersion: 1`, `activeSessionId`, `sessions[]`. Schema mismatch causes clean-slate reset (no migration), since goose is the source of truth.
+- `GroupedSessions`: session list bucketed for UI as Today / Yesterday / `Month Day, Year`; sessions sort newest-first within a bucket.
+**Implementation**: `src/shared/sessionTypes.ts`, `src/extension/sessionStorage.ts`
 
 ### AgentCapabilities
-**Definition**: Describes ACP agent capabilities received from initialize response. Tracks loadSession support and promptCapabilities (image, audio, embeddedContext).
+**Definition**: Capabilities reported by agent in ACP `initialize` response: `loadSession` (can replay history), `promptCapabilities.{image, audio, embeddedContext}`. `DEFAULT_CAPABILITIES` pre-enables loadSession for modern goose.
 **Implementation**: `src/shared/sessionTypes.ts`
 
 ### GooseError
-**Definition**: Discriminated union of all possible domain errors with `_tag` field for exhaustive type narrowing.
+**Definition**: Closed discriminated union tagged via `_tag`: `BinaryNotFoundError | SubprocessSpawnError | SubprocessCrashError | JsonRpcParseError | JsonRpcTimeoutError | JsonRpcError | VersionMismatchError`. Every variant carries `message` + `timestamp` plus variant-specific fields.
 **Implementation**: `src/shared/errors.ts`
-**Variants**:
-- `BinaryNotFoundError`: Goose binary not found in PATH or configured location
-- `SubprocessSpawnError`: Failed to spawn subprocess
-- `SubprocessCrashError`: Process exited unexpectedly
-- `JsonRpcParseError`: Invalid JSON-RPC response
-- `JsonRpcTimeoutError`: Request exceeded timeout
-- `JsonRpcError`: Protocol-level error response
-- `VersionMismatchError`: Installed version below minimum (1.16.0)
 
-## Technical Concepts
+### JsonRpcRequest / Response / Notification
+**Definition**: JSON-RPC 2.0 wire types. Request has numeric `id` + `method` + `params`; Response returns `result` or `error`; Notification is id-less. All carry `jsonrpc: '2.0'`.
+**Implementation**: `src/shared/types.ts`
 
-### ACP Content Blocks
-**Purpose**: Message content types in Agent Communication Protocol for file context
-**Implementation**: `src/extension/sessionManager.ts`
-**Types**:
-- `text`: Plain text content
-- `resource_link`: File reference by URI (lightweight, Goose reads file)
-- `resource`: Embedded resource with content (for history replay)
+### PendingRequest
+**Definition**: In-flight JSON-RPC request record held in a `Map<id, entry>` inside `JsonRpcClient`: id, method, resolve, reject, timer. Timer enforces 30 s default timeout producing `JsonRpcTimeoutError`.
+**Implementation**: `src/shared/types.ts`, `src/extension/jsonRpcClient.ts`
 
-### WebviewMessage Protocol
-**Purpose**: Typed message passing between extension host and React webview
+### BinaryDiscoveryConfig
+**Definition**: Input bundle for binary discovery — `userConfiguredPath`, `platform`, `env`, `homeDir`. Decouples discovery logic from `process`/`os` globals for testability.
+**Implementation**: `src/extension/binaryDiscovery.ts`
+
+### VersionCheckResult
+**Definition**: Output of version probe: `version` (parsed semver) + `isCompatible` (>= `1.16.0`).
+**Implementation**: `src/extension/versionChecker.ts`
+
+### WebviewMessage<T>
+**Definition**: Generic discriminated `{ type: WebviewMessageType, payload: WebviewMessagePayloads[T] }`. ~24 message types split across Core / Chat / Session / History / Context / Version / Links. Each type has a `create*Message` factory and `is*Message` type guard.
 **Implementation**: `src/shared/messages.ts`
-**Message Types** (24 total):
-- Core: WEBVIEW_READY, STATUS_UPDATE, GET_STATUS, ERROR
-- Chat: SEND_MESSAGE, STREAM_TOKEN, GENERATION_COMPLETE, STOP_GENERATION, GENERATION_CANCELLED
-- Session: CREATE_SESSION, SESSION_CREATED, GET_SESSIONS, SESSIONS_LIST, SELECT_SESSION, SESSION_LOADED
-- History: CHAT_HISTORY, HISTORY_MESSAGE, HISTORY_COMPLETE
-- Context: ADD_CONTEXT_CHIP, FILE_SEARCH, SEARCH_RESULTS, FOCUS_CHAT_INPUT
-- Version: VERSION_STATUS
-- Links: OPEN_EXTERNAL_LINK
 
-### TaskEither Pattern
-**Purpose**: fp-ts type for async operations that can fail with typed errors
-**Usage**: All subprocess and session operations return TaskEither for composable error handling
-**Pattern**:
-```typescript
-pipe(
-  operation(),
-  TE.map(result => transform(result)),
-  TE.mapLeft(error => handleError(error))
-)
-```
+### VersionStatusPayload.status
+**Definition**: Tri-state gating signal: `blocked_missing | blocked_outdated | compatible`. Only `compatible` lets normal chat UI mount.
+**Implementation**: `src/shared/messages.ts`
 
 ## Terminology Glossary
 
-### Business Terms
-- **Goose**: The external AI agent binary that provides coding assistance
-- **ACP**: Agent Communication Protocol - JSON-RPC interface for goose subprocess
-- **Session**: A persistent conversation context with sessionId that can be resumed
-- **Context Chip**: Visual pill representing attached file or code selection in chat input
-- **@ Mention**: Typing @ at word boundary to activate file picker autocomplete
-- **File Picker**: Dropdown for searching and selecting workspace files
-- **Streaming Token**: Incremental text chunk from Goose during response generation
-- **History Replay**: Loading and displaying past session messages when switching sessions
+### Domain Terms
+- **Goose**: external AI agent binary (>= 1.16.0) this extension drives as a subprocess.
+- **ACP**: Agent Communication Protocol — JSON-RPC 2.0 vocabulary (`initialize`, `session/new`, `session/load`, `session/prompt` + `session/update`, `session/cancel`) spoken over stdin/stdout.
+- **ndjson framing**: newline-delimited JSON — one JSON-RPC message per line, parsed by buffering stdout and splitting on `\n`.
+- **Session**: persistent conversation identified by `sessionId`. Metadata persisted locally in `globalState`; transcript owned by goose and replayable via `session/load`.
+- **Context Chip**: removable pill in the chat input representing an attached file or code range. Serialized to an ACP `resource_link` content block when the prompt is sent.
+- **@ Mention**: typing `@` at a word boundary triggers the file-picker dropdown for adding Context Chips.
+- **Streaming Token**: incremental text chunk delivered via `session/update` notifications (`sessionUpdate=agent_message_chunk`) and forwarded to the webview as `STREAM_TOKEN`.
+- **History Replay**: loading a saved session — `session/load` triggers the agent to re-emit past messages as `session/update` notifications, which `SessionManager` converts into `HISTORY_MESSAGE` events.
+- **Resource Link**: ACP content block `{ type: 'resource_link', uri, name, mimeType? }` — lightweight file reference; agent reads the file itself.
+- **Embedded Resource**: ACP content block `{ type: 'resource', resource: { uri, text?, blob?, mimeType? } }` — carries file content inline; used for history replay when `embeddedContext` is on.
+- **sessionUpdate kinds**: discriminator inside `session/update.params.update.sessionUpdate`. Handled values: `user_message_chunk`, `agent_message_chunk` (mapped to `MessageRole`).
 
 ### Technical Terms
-- **TaskEither**: fp-ts type for async operations that can fail with typed error
-- **Discriminated Union**: TypeScript pattern using `_tag` or `type` field for type narrowing
-- **Resource Link**: ACP content type for file references without embedded content
-- **Embedded Context**: ACP capability for sending file content directly in messages
-- **ndjson**: Newline-delimited JSON framing for stdin/stdout communication
-- **Recent Score**: Timestamp ranking for file search results prioritization
+- **TaskEither**: fp-ts `TaskEither<E, A>` — async operation resolving to `Either<E, A>`. Used for all subprocess, version, session, and JSON-RPC flows.
+- **Discriminated Union**: TypeScript closed union narrowed by a literal tag — `_tag` for `GooseError`, `type` for ACP content blocks and `ParseResult`.
+- **Recent Score**: timestamp-based ranking that sorts `FileSearchResult` so recently-touched files appear first in the @-picker.
+- **File Reference Pattern**: two markdown shapes Goose emits to attach a file — H1 style (`# /abs/path` + fenced block) and File-prefix style (`File: /abs/path:start-end` + fenced block).
+- **Version Gating**: at activation, the extension runs `goose --version`, parses semver, and refuses to initialize ACP unless `>= MINIMUM_VERSION` (1.16.0). Result is surfaced via `VERSION_STATUS`.
+- **Thin UI Bridge**: architectural tenet from `AGENTS.md`/`ARCHITECTURE.md` — the extension owns no business logic, only orchestration between VS Code UI, webview, and goose.
+
+## Relationships
+
+- `ContextChip -> MessageContext` — chips attached at send-time are serialized into `MessageContext` entries on the outgoing `ChatMessage`.
+- `ContextChip -> ACP resource_link` — on `session/prompt`, chips become `resource_link` content blocks (uri=`file://path`, optional range).
+- `FileSearchResult -> ContextChip` — selecting a picker result creates a `ContextChip` for the input.
+- `SessionManager -> JsonRpcClient` — SessionManager issues `session/new` and `session/load` via the shared JsonRpcClient and subscribes to its notifications.
+- `SessionManager -> SessionStorage` — authoritative remote state is goose; SessionManager mirrors `SessionEntry` metadata into VS Code `globalState`.
+- `SubprocessManager -> JsonRpcClient` — on successful spawn, SubprocessManager constructs a JsonRpcClient over the child's stdin/stdout.
+- `JsonRpcClient -> GooseError` — request failures surface as `JsonRpcError`, `JsonRpcParseError`, or `JsonRpcTimeoutError`.
+- `VersionChecker -> SubprocessManager` — version check must succeed before the ACP subprocess may start.
+- `session/update -> HISTORY_MESSAGE / STREAM_TOKEN` — SessionManager demultiplexes `session/update` notifications into `HISTORY_MESSAGE` events (during load) or streaming-token events (during live prompt).
+- `AgentCapabilities.loadSession -> History Replay` — if `loadSession` is false, SessionManager skips `session/load` and marks history unavailable on the `SESSION_LOADED` payload.
+
+## Bounded Contexts
+
+- **Shared Types (`src/shared/`)**: `ProcessStatus`, `ChatMessage`, `MessageContext`, `ContextChip`, `FileSearchResult`, `ParsedFileReference`, `SessionEntry`, `SessionStorageData`, `AgentCapabilities`, `GooseError`, JSON-RPC types, `WebviewMessage` protocol.
+- **Extension Host — Node (`src/extension/`)**: `BinaryDiscovery`, `VersionChecker`, `SubprocessManager`, `JsonRpcClient`, `SessionManager`, `SessionStorage`, config reader (`goose.binaryPath`, `goose.logLevel`).
+- **Webview — React (`src/webview/`)**: `ChatState`, Context Chips UI, `@` picker, history replay rendering, file-reference parsing for cards.
+- **ACP Boundary (stdin/stdout of goose subprocess)**: `initialize`, `session/new`, `session/load`, `session/prompt`, `session/update`, `session/cancel`; ACP content blocks (`text | resource_link | resource`).
+
+## Cross-Cutting Concerns
+
+- **Error Handling**: all fallible paths return fp-ts `Either`/`TaskEither` of `GooseError` variants; no thrown errors escape module boundaries; `formatError` centralizes user-facing copy.
+- **Logging**: shared `Logger` injected into every manager; log level from `goose.logLevel` via `parseLogLevel`; `JsonRpcClient` logs every Received/Notification line at `debug`.
+- **Configuration**: read via `vscode.workspace.getConfiguration('goose')`. `goose.binaryPath` and `goose.logLevel` exposed; `onConfigChange` + `affectsSetting` for reactive updates.
+- **Lifecycle / Disposal**: every manager exposes `dispose()` that clears callbacks, timers, and pending requests; SubprocessManager performs graceful SIGTERM with 5 s timeout before SIGKILL.
+- **Capability Negotiation**: `AgentCapabilities` captured from `initialize` response; `hasLoadSessionCapability` / `hasEmbeddedContextCapability` gate optional requests.
+- **Identity Generation**: local ids use `${Date.now()}-${random36}` pattern for ChatMessage ids and similar ephemeral identifiers; session ids come from goose via `session/new`.
+- **Timeouts**: JSON-RPC requests default to 30 s (`DEFAULT_TIMEOUT_MS`) producing `JsonRpcTimeoutError`; version probe uses 5 s; subprocess graceful shutdown uses 5 s before SIGKILL.
 
 ## Cross-References
-- **Architecture Patterns**: See [architecture.md#patterns]
-- **Module Structure**: See [modules.md]
-- **Implementation Patterns**: See [patterns.md]
+
+- **Architecture & data flows**: See [architecture.md](architecture.md)
+- **Cross-surface behavior**: See [interaction-model.md](interaction-model.md)
+- **Module inventory**: See [modules.md](modules.md)
+- **Implementation patterns**: See [patterns.md](patterns.md)

--- a/.rp1/context/index.md
+++ b/.rp1/context/index.md
@@ -1,21 +1,33 @@
-# VS Code Goose - Knowledge Base
+---
+scope: kbRoot
+path_pattern: "index.md"
+producer: knowledge-base
+type: document
+description: "Project overview and progressive KB entry point. Always generated -- serves as the navigation hub for all other KB documents."
+strictness: strict
+---
+# vscode-goose — Knowledge Base
 
 **Type**: Single Project
-**Languages**: TypeScript, TSX (React)
-**Version**: 0.1.0
-**Updated**: 2025-12-21
+**Languages**: TypeScript, TSX, CSS
+**Version**: 0.2.1
+**Updated**: 2026-04-23
 
 ## Project Summary
 
-VS Code extension providing a thin UI bridge to Goose AI agent via Agent Communication Protocol (ACP). Enables chat-based coding assistance with context attachment, file search, and session management directly within VS Code.
+vscode-goose is a VS Code extension that provides a thin UI bridge over ACP (Agent Communication Protocol) to the Goose AI agent subprocess. The extension owns no AI behavior — it orchestrates VS Code surfaces (chat webview, editor selection, commands) with a locally-spawned `goose` binary (≥ 1.16.0) over JSON-RPC 2.0 on ndjson-framed stdio.
 
 ## Quick Reference
 
 | Aspect | Value |
 |--------|-------|
-| Entry Point | `src/extension/extension.ts` |
-| Key Pattern | Bridge/Adapter with Message-Driven Communication |
-| Tech Stack | TypeScript, React 19, Tailwind CSS 4, fp-ts, Bun |
+| Entry Point | `src/extension/extension.ts` (`activate()` on `onStartupFinished`) |
+| Webview Entry | `src/webview/index.tsx` → `<App />` |
+| Key Pattern | Thin UI bridge; message-driven; version-gated activation |
+| Error Model | fp-ts `TaskEither<GooseError, T>` |
+| Tech Stack | VS Code API `^1.95.0`, React 19, Tailwind 4, fp-ts 2, react-markdown |
+| Runtime / Tooling | Bun (runtime + bundler + tests), Biome 2 (lint+format), Husky + commitlint, release-please |
+| Packaging | `vsce package --no-dependencies` → VSIX, tag prefix `vscode-v`, publisher `block` |
 
 ## KB File Manifest
 
@@ -23,10 +35,11 @@ VS Code extension providing a thin UI bridge to Goose AI agent via Agent Communi
 
 | File | Lines | Load For |
 |------|-------|----------|
-| architecture.md | ~137 | System design, component relationships, data flows |
-| modules.md | ~160 | Component breakdown, module responsibilities |
-| patterns.md | ~70 | Code conventions, implementation patterns |
-| concept_map.md | ~150 | Domain terminology, business concepts |
+| architecture.md | ~218 | System design, component relationships, data flows, deployment |
+| interaction-model.md | ~122 | Cross-surface interaction semantics, UX principles, a11y |
+| modules.md | ~170 | Component breakdown, module responsibilities, metrics |
+| patterns.md | ~121 | Code conventions, error handling, testing, tooling |
+| concept_map.md | ~146 | Domain terminology, ACP vocabulary, type relationships |
 
 ## Task-Based Loading
 
@@ -35,7 +48,7 @@ VS Code extension providing a thin UI bridge to Goose AI agent via Agent Communi
 | Code review | `patterns.md` |
 | Bug investigation | `architecture.md`, `modules.md` |
 | Feature implementation | `modules.md`, `patterns.md` |
-| Context chip work | `concept_map.md`, `modules.md` |
+| Frontend / UX / surface work | `interaction-model.md`, `modules.md`, `patterns.md` |
 | Strategic analysis | ALL files |
 
 ## How to Load
@@ -48,42 +61,20 @@ Read: .rp1/context/{filename}
 
 ```
 src/
-├── extension/      # VS Code extension host (Node.js)
-│   ├── extension.ts      # Main entry, activation orchestration
-│   ├── subprocessManager.ts # Goose process lifecycle
-│   ├── jsonRpcClient.ts  # ACP JSON-RPC communication
-│   ├── sessionManager.ts # Session lifecycle, ACP coordination
-│   ├── versionChecker.ts # Binary version validation (>= 1.16.0)
-│   ├── fileSearchService.ts # @ file picker search
-│   ├── commands.ts       # Command registration (Cmd+Shift+G)
-│   └── webviewProvider.ts # Webview lifecycle, ready sync
-├── webview/        # React chat UI (sandboxed iframe)
-│   ├── App.tsx           # Root with status, session, chat
-│   ├── bridge.ts         # postMessage abstraction
-│   ├── hooks/            # useChat, useContextChips, useFilePicker
-│   ├── components/
-│   │   ├── chat/         # ChatView, InputArea, ChipStack
-│   │   ├── picker/       # FilePicker dropdown
-│   │   └── session/      # SessionHeader, SessionList
-└── shared/         # Shared types between extension/webview
-    ├── messages.ts       # 24 WebviewMessage types
-    ├── types.ts          # ProcessStatus, ChatMessage
-    ├── errors.ts         # GooseError discriminated union
-    ├── contextTypes.ts   # ContextChip, FileSearchResult
-    └── fileReferenceParser.ts # Parse file refs from markdown
+├── extension/        # Node host: activation, subprocess, ACP client, session mgmt, webview provider
+├── webview/          # React 19 iframe UI
+│   ├── components/   # chat/, picker/, session/, markdown/, icons/, VersionBlockedView
+│   ├── hooks/        # useChat, useSession, useContextChips, useFilePicker, useKeyboardNav, useAutoScroll
+│   ├── App.tsx · index.tsx · bridge.ts · theme.ts · styles.css
+└── shared/           # Cross-boundary types: messages, types, contextTypes, sessionTypes, errors, fileReferenceParser
+src/test/mocks/       # Shared test doubles (vscode API, ndjson streams)
+.github/workflows/    # ci.yml (main + release-please), pr-checks.yml
 ```
-
-## Key Features
-
-- **Context Chips**: Attach files/selections via @ picker or Cmd+Shift+G
-- **Version Gating**: Validates goose >= 1.16.0 before activation
-- **Session Management**: Persistent sessions with history replay
-- **Streaming Responses**: Token-by-token AI response display
-- **fp-ts Error Handling**: TaskEither for typed async errors
 
 ## Navigation
 
-- **[architecture.md](architecture.md)**: System design and diagrams
-- **[modules.md](modules.md)**: Component breakdown
-- **[patterns.md](patterns.md)**: Code conventions
-- **[concept_map.md](concept_map.md)**: Domain terminology
+- **[architecture.md](architecture.md)** — System design, Mermaid topology, data flows, CI/release
+- **[interaction-model.md](interaction-model.md)** — Surfaces, user-visible states, feedback loops, a11y
+- **[modules.md](modules.md)** — Module inventory, component table, dependency graph, metrics
+- **[patterns.md](patterns.md)** — Conventions, typing, error channel, tooling (Bun + Biome)
+- **[concept_map.md](concept_map.md)** — Types, glossary (Goose, ACP, chips, sessionUpdate), relationships

--- a/.rp1/context/interaction-model.md
+++ b/.rp1/context/interaction-model.md
@@ -1,0 +1,122 @@
+---
+scope: kbRoot
+path_pattern: "interaction-model.md"
+producer: knowledge-base
+type: document
+description: "Cross-surface interaction semantics, UX principles, user-visible states, and accessibility constraints for a single-project codebase."
+strictness: strict
+---
+# vscode-goose — Interaction Model
+
+**Project**: vscode-goose
+**Analysis Date**: 2026-04-23
+**Surfaces**: VS Code webview (chat), editor context menu + keybinding, command palette, output channel, settings, notifications
+
+## Experience Principles
+
+- **Thin UI bridge, no bloat** — The extension is deliberately a thin bridge between VS Code and the Goose ACP agent; every surface stays minimal and defers agent semantics to Goose. Evidence: `AGENTS.md`, `webviewProvider.ts` (single chat view), `commands.ts` (only 3 commands).
+- **Native VS Code aesthetic via CSS variables** — Colors, fonts, focus rings, badges, hover backgrounds, and list selections are bound to VS Code theme tokens so the webview inherits the user's theme automatically. Evidence: `src/webview/theme.ts`, `src/webview/styles.css`, pervasive `var(--vscode-*)` usage.
+- **Ready-gate + replay for extension → webview messages** — The extension never assumes the webview is mounted. Messages are queued until a `WEBVIEW_READY` signal, then flushed; last process/version status is re-sent on reconnect. Evidence: `webviewProvider.ts` (`messageQueue`, `flushQueue`, `resendState`, `waitForReady`), `bridge.ts` (`createWebviewReadyMessage`).
+- **Stream-first, cancelable generation** — Assistant responses stream token-by-token with a live cursor and a Stop control that is always one key or click away. Cancel is first-class. Evidence: `useChat.ts` (`STREAM_TOKEN`/`COMPLETE_GENERATION`/`CANCEL_GENERATION`), `MarkdownRenderer.tsx` (cursor when streaming), `AssistantMessage.tsx` (`(cancelled)`), `StopButton.tsx`, `useKeyboardNav.ts` (Escape while generating).
+- **Keyboard-first input with chip integration** — `Enter` sends, `Shift+Enter` adds a newline, `@` opens file picker, `Backspace`/`ArrowLeft` at cursor-0 jumps into the chip stack, `Cmd/Ctrl+Up/Down` navigates message history, `Escape` stops generation. Evidence: `InputArea.tsx`, `useFilePicker.ts`, `useKeyboardNav.ts`.
+- **Glanceable session identity** — The top bar always shows the active session title (or `New Session`) plus two affordances (New Chat, History). Session list groups by date and shows cwd. Evidence: `SessionHeader.tsx`, `SessionList.tsx`, `SessionCard.tsx`.
+- **Version gating before anything else** — If Goose is missing or outdated, the chat UI is replaced wholesale by a blocking guidance view with a single CTA (Install / Update). Evidence: `App.tsx` `isVersionBlocked` short-circuit, `VersionBlockedView.tsx`, `webviewProvider.updateVersionStatus`.
+
+## Actors & Surfaces
+
+| Actor | Surface | Goal | Entry Points |
+|-------|---------|------|--------------|
+| VS Code developer | Activity-bar chat webview | chat with Goose, attach context, resume sessions | activity bar `Goose`, sidebar toggle, `goose.chatView.focus` |
+| VS Code developer | Editor context menu + keybinding | send selection to chat | right-click → "Send to Goose", `Cmd/Ctrl+Shift+G` |
+| VS Code developer | Command palette | discoverable operator actions | `Goose: Show Logs`, `Goose: Restart`, `Send to Goose` |
+| Extension operator | Output channel "Goose" | diagnose activation / subprocess / bus | `Goose: Show Logs` |
+| Extension operator | Settings (`goose.*`) | configure binary path, log level | VS Code Settings UI / `settings.json` |
+| VS Code developer | Notifications | read status of restart / missing binary | triggered by `goose.restart` |
+
+## Primary Actions
+
+### Goose chat webview (activity bar)
+**Role**: Primary conversation surface; hosts the React app with session header, history panel, message list, chips, input, and file picker.
+**Primary actions**: type + send a message · stop generation · open `@` file picker · remove / navigate context chips · retry a failed message · copy assistant output · expand truncated history messages · open/close session history panel · start new session · select existing session.
+**Intentional constraints**: no tool-approval UI, no model switcher, no agent config — agent lives in goose; chat UI stays minimal.
+**Evidence**: `package.json` views.goose, `App.tsx`, `ChatView.tsx`, `SessionHeader.tsx`, `SessionList.tsx`.
+
+### Editor context menu + keybinding
+**Role**: Context-ingestion surface that ships the current selection (or whole file) into the active chat as a context chip.
+**Primary actions**: add selection/file as context chip · auto-focus the chat input.
+**Evidence**: `package.json` `menus.editor/context` + `keybindings`, `commands.ts` `registerTextEditorCommand('goose.sendSelectionToChat')` posts `ADD_CONTEXT_CHIP` + `FOCUS_CHAT_INPUT`.
+
+### Command palette
+**Role**: Discoverable surface for operator-level actions.
+**Primary actions**: reveal output channel · restart subprocess · send selection to chat.
+**Evidence**: `package.json` `contributes.commands`.
+
+### Output channel ("Goose")
+**Role**: Read-only log surface for troubleshooting binary discovery, subprocess, and message-bus events.
+**Primary actions**: read logs.
+**Evidence**: `commands.ts` (`outputChannel.show`).
+
+### Settings (Goose section)
+**Role**: Configuration for binary path and log level.
+**Primary actions**: set `goose.binaryPath` · set `goose.logLevel`.
+**Evidence**: `package.json` `contributes.configuration`.
+
+### VS Code notifications
+**Role**: Transient feedback for operator actions outside the chat panel.
+**Primary actions**: read message · dismiss.
+**Evidence**: `commands.ts` (`showInformationMessage` / `showWarningMessage` / `showErrorMessage` in `goose.restart`).
+
+## User-Visible States
+
+| State | Meaning | Surface Signals |
+|-------|---------|-----------------|
+| `STOPPED` / `STARTING` / `RUNNING` / `ERROR` | subprocess lifecycle | "Waiting for Goose…" (stopped), "Connecting to Goose…" (starting), "Connection error" + "Please check the Goose binary path in settings" (error), chat UI mounts only on `RUNNING` |
+| `blocked_missing` / `blocked_outdated` | version gate failure | full-screen "Welcome to Goose" (install CTA) / "Goose Update Required" with detected vs minimum version |
+| Message generating (`STREAMING`) | assistant is producing tokens | SendButton → StopButton; blinking cursor appended to streamed markdown; `ProgressIndicator` (three bouncing dots + "Goose is thinking…" SR text) while content is empty; `aria-busy=true` on chat container |
+| Message `CANCELLED` | user stopped generation mid-stream | `(cancelled)` label next to assistant timestamp |
+| Message `ERROR` | send/generation failed | red-bordered error bubble with error icon; inline "Retry" when `originalContent` retained; `role="alert"` |
+| Empty chat (new/empty session) | no messages yet | `GooseWatermark` centered in the message area; `New Session` header |
+| Session history loading / unavailable | hydrating a session, or history could not be loaded | "Loading session history…" strip; "Session history is not available. Continue from where you left off." warning strip |
+| History message | replayed from persisted history | italic "Earlier" timestamp; "Show more (N lines)" / "Show less" toggle; no streaming cursor |
+| File picker open | `@` triggered at word boundary | dropdown above input with filename/relative path; highlighted selected row; "No results found" for empty queries |
+| Copy feedback | clipboard attempt outcome | icon+label swaps to "Copied!" (green) or "Failed" (red) for ~2 s |
+
+## Feedback Loops
+
+- **Send → stream → complete** — User bubble appears immediately; SendButton swaps to StopButton; ProgressIndicator until first token; tokens stream into assistant bubble with blinking cursor; final state hides cursor and enables Copy on hover. Evidence: `useChat.ts` (`ADD_USER_MESSAGE → START_GENERATION → STREAM_TOKEN → COMPLETE_GENERATION`), `InputArea.tsx`, `AssistantMessage.tsx` group-hover copy.
+- **Stop mid-generation** — StopButton or Escape while generating → `STOP_GENERATION` → assistant marked `(cancelled)` → input returns to Send. Evidence: `StopButton.tsx`, `useKeyboardNav.ts`, `useChat.ts` `CANCEL_GENERATION`.
+- **Error → Retry** — Generation fails with `originalContent` preserved → red error bubble with Retry link → retry re-sends as a fresh user message with a new response id. Evidence: `ErrorMessage.tsx`, `useChat.ts` `retryMessage`.
+- **Editor selection → context chip** — `Send to Goose` focuses view, auto-creates session if missing, waits for ready, chip appears with `filename[:start-end]`, input focused, SR announces "Added context: <name>". Evidence: `commands.ts`, `webviewProvider.waitForReady`, `useContextChips.ts` `ADD_CHIP`, `InputArea.tsx` `FOCUS_CHAT_INPUT`.
+- **@ file picker** — `@` trigger → debounced (~100 ms) search → dropdown opens → keyboard nav → Enter/Tab inserts chip and removes `@query` → Escape/outside click closes. Evidence: `useFilePicker.ts` (`detectAtTrigger`, `DEBOUNCE_MS=100`, `selectResult`), `fileSearchService.ts`.
+- **Session switch** — Click History → pick a card → loading strip → `HISTORY`/`HISTORY_COMPLETE` replay → panel closes → header title updates → history-unavailable banner if applicable. Evidence: `SessionList.tsx`, `useSession.ts`, `App.tsx` banners.
+- **Restart subprocess** — `Goose: Restart` → warning if manager absent, error if binary not found or start fails, info "Goose restarted successfully" on success. Webview reconnects via ready signal; state is re-sent. Evidence: `commands.ts`, `webviewProvider.resendState`.
+- **Auto-scroll during streaming** — New tokens arrive while near bottom → pin; if user scrolls up mid-stream, auto-scroll yields until they return. Evidence: `useAutoScroll.ts` (`userScrolledUp` ref, threshold 100).
+
+## Accessibility & Discoverability
+
+- **Semantic landmarks**: `ChatView.tsx` uses `aria-label="Chat with Goose"`, `aria-busy`; `MessageList.tsx` `role="log"` + `aria-live="polite"`; `MessageItem.tsx` `role="article"` / `role="alert"` for errors.
+- **Live-region announcements for chips**: `useContextChips.ts` announcement strings; `ChipStack.tsx` `role="status"` `aria-live="polite"` sr-only region.
+- **Keyboard navigation for chips**: `ChipStack.tsx` ArrowLeft/Right, Delete/Backspace, Tab/Escape; `ContextChip.tsx` `role="button"` `tabIndex=0`, descriptive aria-label.
+- **Keyboard navigation across messages**: `useKeyboardNav.ts` Cmd/Ctrl+ArrowUp/Down with Mac detection; `MessageList.scrollToMessage`.
+- **Escape stops generation**: `useKeyboardNav.ts` Escape branch → `StopButton` action.
+- **Reduced motion**: `styles.css` `@media (prefers-reduced-motion: reduce)` typing-pulse keyframes.
+- **Theme tokens only**: `theme.ts` + `styles.css` `@theme`; `var(--vscode-focusBorder)` for focus rings.
+- **Strict webview CSP with nonce**: `webviewProvider.ts getWebviewContent` sets `default-src 'none'; script-src 'nonce-…'`; `localResourceRoots` restricted to `dist/webview`.
+- **External links routed via host**: `MarkdownRenderer.tsx` posts `OPEN_EXTERNAL_LINK`; `VersionBlockedView.tsx` uses same flow for install/update CTAs.
+- **Labeled icon-only buttons**: `SessionHeader`, `SessionList`, `SendButton`, `StopButton`, `CopyButton` — all carry `aria-label` + `title`.
+
+## Cross-Surface Deltas
+
+| Behavior | Surfaces | Delta | Reason |
+|----------|----------|-------|--------|
+| Context ingestion | Editor menu/shortcut vs webview `@` picker | Editor path attaches selection with line range; `@` picker attaches whole-file (no range) and suppresses duplicates | Selections carry intentional range; `@` browsing is file-scoped and refined later conversationally |
+| Active-session requirement | Editor command vs webview Send | Editor-to-chat path auto-creates a session if none exists; webview Send assumes a session already exists (status must be `RUNNING`) | `Send to Goose` from editor must never fail; in-webview users already have visible session context |
+| Message timestamps | Live vs replayed history | Live: localized `HH:MM`; history: italic "Earlier" placeholder, truncated to 15 lines by default | History messages often lack precise timestamps and can be long; collapsing keeps replay glanceable |
+| Version enforcement | Webview chat vs command palette | Full-screen blocking view in webview; operator commands (`Goose: Restart`, `Goose: Show Logs`) remain available | Operators must retain remediation paths when chat is blocked |
+
+## Related KB Links
+
+- **System topology**: See [architecture.md](architecture.md)
+- **Component inventory**: See [modules.md](modules.md)
+- **Terminology**: See [concept_map.md](concept_map.md)
+- **Implementation details**: See [patterns.md](patterns.md)

--- a/.rp1/context/modules.md
+++ b/.rp1/context/modules.md
@@ -1,179 +1,170 @@
+---
+scope: kbRoot
+path_pattern: "modules.md"
+producer: knowledge-base
+type: document
+description: "Module and component breakdown with dependency graphs, metrics, and code quality insights for a single-project codebase."
+strictness: strict
+---
 # Module & Component Breakdown
 
-**Project**: VS Code Goose
-**Analysis Date**: 2025-12-21
-**Modules Analyzed**: 7 module groups
+**Project**: vscode-goose
+**Analysis Date**: 2026-04-23
+**Modules Analyzed**: 10
 
 ## Core Modules
 
-### Extension Module (`src/extension/`)
-**Purpose**: VS Code extension host - manages lifecycle, subprocess, ACP session, version checking, file search
-**Files**: 12 | **Lines**: ~2,100
+### `src/extension/`
+**Purpose**: VS Code extension host — lifecycle, subprocess, ACP session, version checking, file search, webview hosting.
+**Complexity**: Medium–High
+**File count**: 12 non-test .ts
+**Key files**: `extension.ts`, `subprocessManager.ts`, `jsonRpcClient.ts`, `sessionManager.ts`, `webviewProvider.ts`, `commands.ts`, `versionChecker.ts`, `fileSearchService.ts`, `binaryDiscovery.ts`, `sessionStorage.ts`, `config.ts`, `logger.ts`.
+**Testing**: colocated `*.test.ts` (binaryDiscovery, sessionStorage, versionChecker, jsonRpcClient) + `subprocess.integration.test.ts`.
 
-**Key Components**:
-| Component | File | Purpose |
-|-----------|------|---------|
-| Extension Entry | `extension.ts` | Orchestrates activation, ACP session init, wires components |
-| SubprocessManager | `subprocessManager.ts` | Spawns goose binary, manages lifecycle events |
-| JsonRpcClient | `jsonRpcClient.ts` | JSON-RPC 2.0 client with ndjson framing |
-| SessionManager | `sessionManager.ts` | Session lifecycle, history replay, ACP coordination |
-| WebviewProvider | `webviewProvider.ts` | Webview lifecycle, message queue, ready sync |
-| Commands | `commands.ts` | Command registration (showLogs, restart, sendSelectionToChat) |
-| VersionChecker | `versionChecker.ts` | Binary version validation (>= 1.16.0) |
-| FileSearchService | `fileSearchService.ts` | Workspace file search for @ picker |
-| BinaryDiscovery | `binaryDiscovery.ts` | Cross-platform goose binary discovery |
-| SessionStorage | `sessionStorage.ts` | Persists session metadata to globalState |
-| Config | `config.ts` | VS Code configuration reader |
-| Logger | `logger.ts` | Source-tagged logger using OutputChannel |
+### `src/shared/`
+**Purpose**: Cross-boundary type contracts and small utilities compiled into both bundles.
+**Complexity**: Low
+**File count**: 7 non-test .ts
+**Key files**: `messages.ts`, `types.ts`, `contextTypes.ts`, `sessionTypes.ts`, `errors.ts`, `fileReferenceParser.ts`, `index.ts`.
+**Testing**: `types.test.ts`, `messages.test.ts`, `errors.test.ts`, `fileReferenceParser.test.ts`.
 
-### Shared Module (`src/shared/`)
-**Purpose**: Shared types and utilities between extension and webview
-**Files**: 7 | **Lines**: ~1,100
+### `src/webview/`
+**Purpose**: React 19 chat UI rendered inside sandboxed VS Code webview iframe.
+**Key files**: `App.tsx`, `index.tsx`, `bridge.ts`, `theme.ts`; `styles.css` (Tailwind 4 build output).
 
-**Key Components**:
-| Component | File | Purpose |
-|-----------|------|---------|
-| Messages | `messages.ts` | 24 WebviewMessage types, factories, guards (~700 lines) |
-| Types | `types.ts` | ProcessStatus, ChatMessage, MessageRole, MessageContext |
-| ContextTypes | `contextTypes.ts` | ContextChip, FileSearchResult, LineRange |
-| SessionTypes | `sessionTypes.ts` | SessionEntry, AgentCapabilities, groupSessionsByDate |
-| Errors | `errors.ts` | GooseError discriminated union, factory functions |
-| FileReferenceParser | `fileReferenceParser.ts` | Parse file references from markdown |
-| Index | `index.ts` | Re-exports for convenient imports |
+### `src/webview/hooks/`
+**Purpose**: State management hooks for chat, session, context chips, file picker, autoscroll, keyboard nav.
+**Key files**: `useChat.ts`, `useSession.ts`, `useContextChips.ts`, `useFilePicker.ts`, `useAutoScroll.ts`, `useKeyboardNav.ts`.
 
-### Webview Module (`src/webview/`)
-**Purpose**: React-based chat UI in sandboxed iframe
-**Files**: 28 | **Lines**: ~2,500
+### `src/webview/components/chat/`
+**Purpose**: Chat UI primitives (container, view, message list/items, input area, chips, buttons, progress, errors).
+**Key files**: `ChatContainer.tsx`, `ChatView.tsx`, `MessageList.tsx`, `MessageItem.tsx`, `InputArea.tsx`, `ChipStack.tsx`, `ContextChip.tsx`, `AssistantMessage.tsx`, `UserMessage.tsx`, `FileReferenceCard.tsx`, `SendButton.tsx`, `StopButton.tsx`, `ProgressIndicator.tsx`, `ErrorMessage.tsx`, `index.ts`.
 
-**Sub-modules**:
-- `hooks/` - State management hooks (6 files)
-- `components/chat/` - Chat UI components (15 files)
-- `components/picker/` - File picker dropdown (2 files)
-- `components/icons/` - File type icons (2 files)
-- `components/session/` - Session management UI (3 files)
-- `components/markdown/` - Markdown rendering (3 files)
+### `src/webview/components/picker/`
+**Purpose**: `@`-mention file picker dropdown.
+**Key files**: `FilePicker.tsx`, `FilePickerItem.tsx`, `index.ts`.
+
+### `src/webview/components/session/`
+**Purpose**: Session management UI — header, list, per-session card.
+**Key files**: `SessionHeader.tsx`, `SessionList.tsx`, `SessionCard.tsx`, `index.ts`.
+
+### `src/webview/components/markdown/`
+**Purpose**: Markdown rendering with code blocks + copy affordance.
+**Key files**: `MarkdownRenderer.tsx`, `CodeBlock.tsx`, `CopyButton.tsx`.
+
+### `src/webview/components/icons/`
+**Purpose**: Icon assets — file-type glyph and Goose watermark.
+**Key files**: `FileTypeIcon.tsx`, `GooseWatermark.tsx`.
+
+### `src/test/mocks/`
+**Purpose**: Shared test doubles for the `vscode` API and ndjson streams used across unit + integration tests.
+**Key files**: `vscode.ts`, `streams.ts`, `mocks.test.ts`.
 
 ## Key Components
 
-### SubprocessManager
-**File**: `src/extension/subprocessManager.ts`
-**Purpose**: Manage goose subprocess from spawn to termination
-**Responsibilities**:
-- Spawn goose binary with ACP protocol
-- Handle process lifecycle events (exit, error)
-- Provide JsonRpcClient access
-- Graceful shutdown with SIGTERM then SIGKILL
-
-### JsonRpcClient
-**File**: `src/extension/jsonRpcClient.ts`
-**Purpose**: JSON-RPC 2.0 over stdin/stdout with ndjson framing
-**Responsibilities**:
-- Send requests with timeout handling
-- Route responses and notifications
-- Manage pending request lifecycle
-
-### SessionManager
-**File**: `src/extension/sessionManager.ts`
-**Purpose**: Coordinate session state between ACP and storage
-**Responsibilities**:
-- Create new ACP sessions
-- Load sessions with history replay
-- Track active session and capabilities
-- TaskEither-based API for error handling
-
-### WebviewProvider
-**File**: `src/extension/webviewProvider.ts`
-**Purpose**: VS Code WebviewViewProvider for chat panel
-**Responsibilities**:
-- Generate secure HTML with CSP
-- Queue messages until webview ready
-- Handle ready sync and reconnection
-- Status and version status updates
-
-### useChat Hook
-**File**: `src/webview/hooks/useChat.ts`
-**Purpose**: Chat message state management
-**Responsibilities**:
-- Reducer-based state with typed actions
-- Handle streaming tokens
-- Send messages with context chips
-- Persist input draft
-
-### useContextChips Hook
-**File**: `src/webview/hooks/useContextChips.ts`
-**Purpose**: Context chip state management
-**Responsibilities**:
-- Handle ADD_CONTEXT_CHIP messages
-- Detect duplicates
-- Keyboard navigation support
-- Aria-live announcements
-
-### useFilePicker Hook
-**File**: `src/webview/hooks/useFilePicker.ts`
-**Purpose**: @ mention file search
-**Responsibilities**:
-- Detect @ trigger at word boundary
-- Debounced search (100ms)
-- Keyboard navigation
-- Remove @query after selection
+| Component | File | Role | Primary responsibilities |
+|-----------|------|------|--------------------------|
+| Extension Entry | `src/extension/extension.ts` | entrypoint | activate()/deactivate(); wire services; version gate; register commands + webview |
+| SubprocessManager | `src/extension/subprocessManager.ts` | service | spawn goose; expose JsonRpcClient; emit exit/error; graceful SIGTERM→SIGKILL |
+| JsonRpcClient | `src/extension/jsonRpcClient.ts` | service | JSON-RPC 2.0 over stdio (ndjson); timeouts; pending-request map |
+| SessionManager | `src/extension/sessionManager.ts` | service | `session/new`/`session/load`; active session + capabilities; TaskEither API |
+| SessionStorage | `src/extension/sessionStorage.ts` | repository | VS Code `globalState` CRUD over `SessionEntry[]`; schemaVersion handling |
+| WebviewProvider | `src/extension/webviewProvider.ts` | controller | `WebviewViewProvider`; CSP nonce HTML; ready-sync queue; status broadcast |
+| Commands | `src/extension/commands.ts` | controller | `goose.showLogs`, `goose.restart`, `goose.sendSelectionToChat` |
+| VersionChecker | `src/extension/versionChecker.ts` | service | invoke `goose --version`; parse semver; gate ≥ 1.16.0 |
+| FileSearchService | `src/extension/fileSearchService.ts` | service | ranked `workspace.findFiles` for `@` picker |
+| BinaryDiscovery | `src/extension/binaryDiscovery.ts` | utility | cross-platform goose binary resolution (config override → PATH → known paths) |
+| Config | `src/extension/config.ts` | utility | typed reader for `goose.*` |
+| Logger | `src/extension/logger.ts` | utility | source-tagged logger over VS Code OutputChannel |
+| Messages | `src/shared/messages.ts` | contract | `WebviewMessage` union + factories + guards (~24 types) |
+| Shared Types | `src/shared/types.ts` | contract | ProcessStatus, ChatMessage, MessageRole, MessageContext |
+| ContextTypes | `src/shared/contextTypes.ts` | contract | ContextChip, FileSearchResult, LineRange |
+| SessionTypes | `src/shared/sessionTypes.ts` | contract | SessionEntry, AgentCapabilities, `groupSessionsByDate` |
+| Errors | `src/shared/errors.ts` | contract | `GooseError` discriminated union + factories |
+| FileReferenceParser | `src/shared/fileReferenceParser.ts` | utility | parse file references from assistant markdown |
+| App | `src/webview/App.tsx` | component | root webview; composes hooks; gates UI on version + ProcessStatus |
+| Bridge | `src/webview/bridge.ts` | utility | typed `postMessage` abstraction over VS Code webview API |
+| useChat / useSession / useContextChips / useFilePicker / useKeyboardNav / useAutoScroll | `src/webview/hooks/*` | hooks | UI state, bridge wiring, keyboard/autoscroll behavior |
+| ChatContainer / InputArea / MarkdownRenderer / FilePicker / SessionList / VersionBlockedView | `src/webview/components/**` | components | layout shell, composer, rendering, pickers, session UI, version-blocked screen |
 
 ## Module Dependencies
 
 ```mermaid
 graph TD
-    EXT[extension.ts] --> SubMgr[subprocessManager]
-    EXT --> SessMgr[sessionManager]
-    EXT --> WebProv[webviewProvider]
-    EXT --> CMD[commands]
-    EXT --> VC[versionChecker]
-    EXT --> FSS[fileSearchService]
-
-    SubMgr --> JsonRpc[jsonRpcClient]
-    SessMgr --> JsonRpc
-    SessMgr --> SessStore[sessionStorage]
-    WebProv --> MSG[shared/messages]
-
-    APP[App.tsx] --> UseChat[useChat]
-    APP --> UseSess[useSession]
-    APP --> UseChips[useContextChips]
-    CV[ChatView] --> IA[InputArea]
-    IA --> UFP[useFilePicker]
-    IA --> CS[ChipStack]
-    IA --> FP[FilePicker]
+    ExtEntry[extension.ts] --> Sub[subprocessManager]
+    ExtEntry --> Ver[versionChecker]
+    ExtEntry --> Disc[binaryDiscovery]
+    ExtEntry --> Sess[sessionManager]
+    ExtEntry --> WvP[webviewProvider]
+    ExtEntry --> Cmd[commands]
+    Sub --> Rpc[jsonRpcClient]
+    Sess --> Rpc
+    Sess --> Store[sessionStorage]
+    WvP --> SharedMsgs[shared/messages]
+    Cmd --> WvP
+    Cmd --> Sub
+    App[webview/App] --> Hooks[webview/hooks]
+    App --> Bridge[webview/bridge]
+    Bridge --> SharedMsgs
+    InputArea[components/chat/InputArea] --> useFilePicker
+    MarkdownRenderer[components/markdown/MarkdownRenderer] --> SharedParser[shared/fileReferenceParser]
+    SharedMsgs --> SharedTypes[shared/{types,contextTypes,sessionTypes,errors}]
 ```
 
-## External Dependencies
-
-| Package | Version | Purpose |
-|---------|---------|---------|
-| vscode | ^1.95.0 | VS Code extension API |
-| fp-ts | ^2.16.0 | Functional programming |
-| react | ^19.1.0 | UI component library |
-| react-markdown | ^10.1.0 | Markdown rendering |
-| react-syntax-highlighter | ^15.6.1 | Code syntax highlighting |
-| @tailwindcss/cli | ^4.1.0 | CSS framework |
+### Import Analysis
+- **Most imported (fan-in)**: `src/shared/messages.ts` (extension + webview consumers).
+- **Most dependencies (fan-out)**: `src/extension/extension.ts` (wires every host-side service).
+- **Circular dependencies**: none detected.
 
 ## Module Metrics
 
-| Module | Files | Lines | Components |
-|--------|-------|-------|------------|
-| extension | 12 | ~2,100 | 12 |
-| shared | 7 | ~1,100 | 6 |
-| webview | 28 | ~2,500 | 24 |
-| webview/hooks | 6 | ~850 | 6 |
-| webview/components/chat | 15 | ~950 | 14 |
-| webview/components/picker | 2 | ~160 | 2 |
+| Module | Files | Components | Internal deps | External deps |
+|--------|-------|------------|---------------|---------------|
+| `src/extension` | 12 | 12 | 11 | 2 (`vscode`, `fp-ts`) |
+| `src/shared` | 7 | 7 | 4 | 0 |
+| `src/webview` | 4 (+ `styles.css`) | 4 | 6 | 2 (`react`, `react-dom`) |
+| `src/webview/hooks` | 6 | 6 | 4 | 1 (`react`) |
+| `src/webview/components/chat` | 15 | 14 | 9 | 1 (`react`) |
+| `src/webview/components/picker` | 3 | 2 | 2 | 1 |
+| `src/webview/components/session` | 4 | 3 | 2 | 1 |
+| `src/webview/components/markdown` | 3 | 3 | 2 | 2 (`react-markdown`, `react-syntax-highlighter`) |
+| `src/webview/components/icons` | 2 | 2 | 0 | 1 |
+| `src/test/mocks` | 3 | — | — | — |
+
+### External Dependencies (runtime)
+- `vscode` `^1.95.0` — VS Code extension API
+- `react` / `react-dom` `^19.1.0` — UI
+- `react-markdown` `^10.1.0`
+- `react-syntax-highlighter` `^15.6.1`
+- `fp-ts` `^2.16.0` — TaskEither-based error handling
+- `@tailwindcss/cli` `^4.1.0` — Tailwind v4 build
+- `@vscode/vsce` — packaging (devDependency)
+
+## Module Boundaries
+
+- **`src/extension`** — public API exposed via `package.json` contributions (commands, view, settings, keybinding); internal services are implementation detail.
+- **`src/shared`** — pure type + factory module; must stay free of VS Code and DOM APIs.
+- **`src/webview`** — communicates with host exclusively through `Bridge` + `shared/messages`.
 
 ## Cross-Module Patterns
 
-### Context Chip Flow
-Editor selection → extension/commands → shared/messages → webview/useContextChips → components/ChipStack → sent with message as resource_link
+- **Bridge + Typed Messages** — single discriminated union in `shared/messages.ts` with factories and guards on both sides. Involved: `extension/webviewProvider`, `webview/bridge`, `shared/messages`.
+- **Ready-Sync Message Queue** — `WebviewProvider` buffers host→webview messages until ready. Involved: `extension/webviewProvider`, `webview/App`.
+- **TaskEither Error Channel** — extension-side services return `TaskEither<GooseError, T>`. Involved: `extension/sessionManager`, `extension/versionChecker`, `shared/errors`.
+- **Context Chip Flow** — editor selection → commands → shared messages → `useContextChips` → `ChipStack` → sent with message as `resource_link`. Involved: `extension/commands`, `shared/messages`, `webview/hooks/useContextChips`, `webview/components/chat/ChipStack`.
+- **File Picker Request/Response** — webview `@` trigger → `FILE_SEARCH_REQUEST` → `fileSearchService` → `FILE_SEARCH_RESULT` → `FilePicker`. Involved: `useFilePicker`, `shared/messages`, `extension/fileSearchService`, `components/picker/FilePicker`.
+- **Version Gating** — `versionChecker` result broadcast as `VERSION_STATUS`; webview swaps chat UI for `VersionBlockedView` when unsupported.
+- **Shared Test Mocks** — `src/test/mocks` centralizes `vscode` API and ndjson stream doubles across unit and integration tests.
 
-### File Picker Request-Response
-Webview @ trigger → shared/messages → extension/fileSearchService → shared/messages → webview/FilePicker dropdown
+## Code Quality Insights
 
-### Version Gating
-extension/versionChecker → shared/messages → webview/VersionBlockedView
+### Well-Structured Modules
+- **`src/shared`** — pure, framework-free contracts with exhaustive factories + guards per message variant.
+- **`src/extension`** — single-responsibility services with consistent TaskEither error channel.
+- **`src/webview/hooks`** — hooks composed as reducers with typed action unions; leaf state lives close to consumers.
 
-### Bridge Communication
-Extension and webview communicate via typed postMessage with factories and guards. Messages are queued until webview ready.
+### Architectural Patterns (applied across modules)
+- **Typed discriminated unions** at every cross-boundary surface.
+- **Ready-sync handshake** for webview mount race conditions.
+- **Capability negotiation** (from ACP `initialize`) gating optional requests in `SessionManager`.
+- **Version-gated activation** before any ACP interaction.

--- a/.rp1/context/patterns.md
+++ b/.rp1/context/patterns.md
@@ -1,88 +1,121 @@
+---
+scope: kbRoot
+path_pattern: "patterns.md"
+producer: knowledge-base
+type: document
+description: "Implementation patterns, coding conventions, and idioms for a single-project codebase. Hard limit of 150 lines."
+strictness: strict
+---
 # Implementation Patterns
 
-**Project**: VS Code Goose
-**Last Updated**: 2025-12-21
+**Project**: vscode-goose
+**Last Updated**: 2026-04-23
+
+## Project Principles
+
+**Design Intent**: Thin UI bridge between VS Code and Goose via ACP — nothing else. No bloat.
+**Aesthetic**: Goose Desktop look & feel as baseline for UI decisions.
+**Style**: Functional programming preferred (fp-ts `Either`/`TaskEither`, readonly data, hooks + pure functions).
+**Library Selection**: Lean, well-supported, latest stable versions when adding dependencies.
+
+Evidence: `AGENTS.md:3-12`, `src/shared/errors.ts`, `src/webview/hooks/useChat.ts`
 
 ## Naming & Organization
 
-**Files**: camelCase for source (versionChecker.ts, useFilePicker.ts, ChipStack.tsx)
-**Functions**: camelCase with verb prefixes: create*, is* for guards, use* for hooks, parse*, handle*
-**Imports**: Named imports, absolute from shared/, relative within same domain
+**Files**: camelCase for source (`versionChecker.ts`, `useFilePicker.ts`); `PascalCase.tsx` for components (`ChipStack.tsx`, `MessageList.tsx`).
+**Functions**: camelCase with verb prefixes — `create*`, `is*` for guards, `use*` for hooks, `parse*`, `handle*`.
+**Imports**: named imports; absolute from `shared/`, relative within same domain; `organizeImports` assist on (`biome.json:335-337`).
+**Layout**: three-layer split — `src/extension` (Node host), `src/webview` (React iframe), `src/shared` (cross-boundary types).
 
-Evidence: src/shared/messages.ts, src/webview/hooks/useFilePicker.ts
+Evidence: `src/shared/messages.ts`, `src/webview/hooks/useFilePicker.ts`, `biome.json:335-337`
 
 ## Type & Data Modeling
 
-**Data Representation**: TypeScript interfaces with readonly modifiers
-**Type Strictness**: Strict typing with explicit return types, mapped types for payload inference
-**Immutability**: Pervasive readonly on properties and arrays (readonly ContextChip[])
-**Discriminated Unions**: `_tag` field for errors, `type` field for messages
+**Data Representation**: TypeScript interfaces with pervasive `readonly`.
+**Type Strictness**: strict with explicit return types; mapped types for payload inference; `noExplicitAny=warn`, `noNonNullAssertion=warn` on extension/shared (`biome.json:178-183`).
+**Immutability**: `readonly` properties and `readonly T[]` by default; `useAsConstAssertion` enforced.
+**Discriminated Unions**: `_tag` for errors, `type` for messages and ACP content blocks.
 
-Evidence: src/shared/errors.ts:66-74, src/shared/contextTypes.ts:1-28
+Evidence: `src/shared/errors.ts:66-74`, `src/shared/contextTypes.ts:1-28`, `biome.json:69,178-183`
 
 ## Error Handling
 
-**Strategy**: fp-ts Either/TaskEither for typed async errors
-**Propagation**: TaskEither returns E.left/E.right, formatError() for user messages
-**Common Types**: BinaryNotFoundError, SubprocessSpawnError, JsonRpcError, VersionMismatchError
+**Strategy**: fp-ts `Either` / `TaskEither` for typed async errors; no throw-at-boundary.
+**Propagation**: `TaskEither` returns `E.left`/`E.right`; `formatError()` centralises user-facing strings.
+**Common Types**: `BinaryNotFoundError`, `SubprocessSpawnError`, `JsonRpcError`, `VersionMismatchError` (tagged union under `GooseError`).
 
-Evidence: src/shared/errors.ts, src/extension/versionChecker.ts:98-181
+Evidence: `src/shared/errors.ts`, `src/extension/versionChecker.ts:98-181`
 
 ## Validation & Boundaries
 
-**Location**: API boundary via type guard functions, message entry points
-**Method**: Generic isWebviewMessage<T> with specializations, regex for content parsing
-**Pattern**: Factory + Guard pairs (createStatusUpdateMessage / isStatusUpdateMessage)
+**Location**: boundary-checked via type-guard functions at message entry points (webview ↔ extension, stdio ↔ client).
+**Method**: generic `isWebviewMessage<T>` with specialised guards; regex for file-reference / `@`-trigger parsing.
+**Pattern**: Factory + Guard pairs — `createStatusUpdateMessage` paired with `isStatusUpdateMessage`.
 
-Evidence: src/shared/messages.ts:538-548, src/shared/fileReferenceParser.ts:53-64
+Evidence: `src/shared/messages.ts:538-548`, `src/shared/fileReferenceParser.ts:53-64`
 
 ## Observability
 
-**Logging**: Custom Logger abstraction with levels: debug, info, warn, error
-**Tracing**: Session IDs and message IDs as correlation identifiers
-**Metrics**: None detected
+**Logging**: custom `Logger` abstraction with `debug`/`info`/`warn`/`error` levels.
+**Tracing**: session ids and message ids as correlation identifiers across extension/webview.
+**Metrics**: none detected.
 
-Evidence: src/extension/logger.ts, src/extension/webviewProvider.ts:52,123
+Evidence: `src/extension/logger.ts`, `src/extension/webviewProvider.ts:52,123`
 
 ## Testing Idioms
 
-**Organization**: Co-located test files (*.test.ts)
-**Framework**: Bun test runner
-**Coverage**: Unit tests for pure functions (version parsing, file reference parsing)
+**Organization**: co-located test files (`*.test.ts` next to source).
+**Framework**: Bun test runner (preferred per `AGENTS.md`).
+**Coverage**: unit tests for pure functions (version parsing, file-reference parsing); `subprocess.integration.test.ts` exercises the subprocess + RPC path.
+**Mocks**: shared in `src/test/mocks` (`vscode.ts`, `streams.ts`).
 
-Evidence: src/extension/versionChecker.test.ts, src/shared/fileReferenceParser.test.ts
+Evidence: `src/extension/versionChecker.test.ts`, `src/shared/fileReferenceParser.test.ts`, `src/test/mocks/*`
 
 ## I/O & Integration
 
-**Subprocess**: spawn with timeout cleanup pattern, JSON-RPC over ndjson-framed stdio
-**State Persistence**: VS Code Memento API (globalState), webview getState/setState
-**Graceful Shutdown**: SIGTERM then SIGKILL after timeout
+**Subprocess**: `spawn` with timeout-cleanup pattern; JSON-RPC over ndjson-framed stdio.
+**Binary Discovery**: path resolution + version gate (≥ 1.16.0) before session start.
+**State Persistence**: VS Code Memento API (`globalState`) for sessions; webview `getState`/`setState` for UI state.
+**Graceful Shutdown**: SIGTERM then SIGKILL after 5 s timeout.
 
-Evidence: src/extension/subprocessManager.ts:86-102, src/extension/jsonRpcClient.ts:109-122
+Evidence: `src/extension/subprocessManager.ts:86-102`, `src/extension/jsonRpcClient.ts:109-122`, `src/extension/binaryDiscovery.ts`
 
 ## Concurrency & Async
 
-**Async Usage**: TaskEither for async operations, Promise-based waitForReady()
-**Patterns**: Message queue with flush on ready, debounced search (100ms)
-**Cleanup**: Returned unsubscribe functions for event handlers
+**Async Usage**: `TaskEither` for typed async; Promise-based `waitForReady()` for webview handshake.
+**Patterns**: message queue with flush-on-ready; debounced search (~100 ms).
+**Cleanup**: subscribe functions return unsubscribe; `useEffect` teardown for event handlers.
 
-Evidence: src/extension/webviewProvider.ts:147-154, src/webview/hooks/useFilePicker.ts:99-106
+Evidence: `src/extension/webviewProvider.ts:147-154`, `src/webview/hooks/useFilePicker.ts:99-106`
 
 ## UI Patterns
 
-**State Management**: useReducer for complex UI state with typed action unions
-**Keyboard Navigation**: handleKeyDown returns boolean to indicate consumed event
-**Focus Management**: Arrow keys for chip navigation, focus restoration on removal
-**Accessibility**: aria-live regions for announcements, role=list/listitem, sr-only class
-**@ Trigger Detection**: Scan backwards from cursor for @ at word boundary
+**State Management**: `useReducer` for complex UI state with typed action unions; local `useState` for leaf concerns.
+**Hooks Discipline**: `useHookAtTopLevel=error`, `useExhaustiveDependencies=warn`, `useJsxKeyInIterable=error` (`biome.json:317-322`).
+**Keyboard Navigation**: `handleKeyDown` returns boolean to indicate consumed event.
+**Focus Management**: arrow keys for chip navigation; focus restoration on removal.
+**Accessibility**: `aria-live` regions for announcements; `role=list/listitem`; `sr-only` class; nonce+CSP webview.
+**@ Trigger Detection**: scan backwards from cursor for `@` at word boundary.
+**Styling**: Tailwind v4 utility classes + VS Code theme tokens via `src/webview/theme.ts`.
 
-Evidence: src/webview/hooks/useChat.ts:25-36, src/webview/components/chat/ChipStack.tsx:34-99
+Evidence: `src/webview/hooks/useChat.ts:25-36`, `src/webview/components/chat/InputArea.tsx`, `src/webview/theme.ts`, `biome.json:317-331`
 
 ## Communication Patterns
 
-**Webview-Extension**: postMessage/onMessage with typed discriminated union messages
-**Ready Sync**: Promise-based waitForReady() with callback accumulation
-**Factory-Guards**: Paired createXMessage() factory and isXMessage() type guard
-**State Resend**: Re-send lastStatus/lastVersionStatus on webview reconnect
+**Webview ↔ Extension**: `postMessage`/`onMessage` with typed discriminated-union messages.
+**Ready Sync**: Promise-based `waitForReady()` with callback accumulation.
+**Factory–Guard Pair**: paired `createXMessage()` + `isXMessage()` per message type.
+**State Resend**: resend last `status` / `versionStatus` on webview reconnect.
 
-Evidence: src/webview/bridge.ts:38-55, src/extension/webviewProvider.ts:105-120
+Evidence: `src/webview/bridge.ts:38-55`, `src/extension/webviewProvider.ts:105-120`
+
+## Tooling & Code Style
+
+**Runtime / Package Manager**: Bun preferred (per `AGENTS.md`); `bun.lock` checked in.
+**Linter / Formatter**: Biome 2.x — 2-space indent, 100-col width, single quotes, double JSX quotes, es5 trailing commas, semicolons always (`biome.json:5-27,109-122`).
+**Module System**: ESM only — `noCommonJs=error`, `noNamespace=error` (`biome.json:65-70`).
+**TS Safety**: `noVar=error`, `useConst=error`, `useAsConstAssertion=error` in TS override (`biome.json:157-169`).
+**Formatting Scope**: `package.json` excluded from formatter (`biome.json:25`).
+**CI / Release**: Conventional Commits enforced by commitlint + Husky; release-please automates SemVer + Release PRs; `vsce package --no-dependencies` builds VSIX from bundled `dist/`.
+
+Evidence: `biome.json:5-27,65-70,109-122,157-169`, `AGENTS.md:9-11`, `.husky/*`, `commitlint.config.js`, `release-please-config.json`

--- a/.rp1/context/state.json
+++ b/.rp1/context/state.json
@@ -1,21 +1,20 @@
 {
   "strategy": "parallel-map-reduce",
   "repo_type": "single-project",
-  "current_project_path": ".",
   "monorepo_projects": [],
-  "generated_at": "2025-12-21T00:00:00.000Z",
-  "git_commit": "d95458d99cfb3ee2201274631da5f7197e94367f",
-  "files_analyzed": 69,
-  "languages": ["TypeScript", "TSX", "CSS"],
-  "frameworks": ["React 19", "VS Code Extension API", "Tailwind CSS 4", "fp-ts", "react-markdown"],
+  "generated_at": "2026-04-23T00:00:00.000Z",
+  "git_commit": "9f0bb705191acc9fca30c91b16c098c276e8c17a",
+  "files_analyzed": 104,
+  "languages": ["TypeScript", "TSX", "CSS", "Markdown"],
+  "frameworks": ["VS Code Extension API", "React 19", "Tailwind CSS 4", "fp-ts", "react-markdown", "ACP"],
   "metrics": {
-    "modules": 7,
+    "modules": 10,
     "components": 42,
     "concepts": 24
   },
   "incremental_update": {
-    "previous_commit": "3c653b9ef95f46e299372a514aa60e0e40b1ad27",
-    "files_changed": 76,
-    "mode": "FULL"
+    "previous_commit": "d95458d99cfb3ee2201274631da5f7197e94367f",
+    "files_changed": 13,
+    "mode": "INCREMENTAL"
   }
 }

--- a/.rp1/context/state.json
+++ b/.rp1/context/state.json
@@ -6,7 +6,14 @@
   "git_commit": "9f0bb705191acc9fca30c91b16c098c276e8c17a",
   "files_analyzed": 104,
   "languages": ["TypeScript", "TSX", "CSS", "Markdown"],
-  "frameworks": ["VS Code Extension API", "React 19", "Tailwind CSS 4", "fp-ts", "react-markdown", "ACP"],
+  "frameworks": [
+    "VS Code Extension API",
+    "React 19",
+    "Tailwind CSS 4",
+    "fp-ts",
+    "react-markdown",
+    "ACP"
+  ],
   "metrics": {
     "modules": 10,
     "components": 42,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,51 @@ The goal of this project is to ensure a thin UI bridge between Goose and VS Code
 
 1. More Context is available here: ./.rp1/context/index.md
 2. Progressively load references available in the above file when more context is needed.
+
+<!-- rp1:start:v0.7.1 -->
+## rp1 Knowledge Base
+
+**Use Progressive Disclosure Pattern**
+
+Location: `.rp1/context/`
+
+Files:
+- index.md (always load first)
+- architecture.md
+- modules.md
+- patterns.md
+- concept_map.md
+
+Loading rules:
+1. Always read index.md first.
+2. Then load based on task type:
+   - Code review: patterns.md
+   - Bug investigation: architecture.md, modules.md
+   - Feature work: modules.md, patterns.md
+   - Strategic or system-wide analysis: all files
+
+## rp1 Skill Awareness
+
+You have access to rp1 skills. When you notice the user working on a task
+that an rp1 skill addresses, briefly suggest it.
+
+### Skill Categories
+| Category | Skills | Suggest When |
+|----------|--------|--------------|
+| Development | /task, /bootstrap, /build, /build-fast, /feature-archive, /feature-edit, /feature-unarchive, /phase-plan, /speedrun | User starts a new feature, describes a change, or needs to scaffold a project |
+| Investigation | /code-investigate, /validate-hypothesis | User is debugging, examining errors, or testing a design hypothesis |
+| Quality | /code-comments, /code-audit, /code-check, /code-clean-comments | User finishes implementation and needs hygiene checks, audits, or comment cleanup |
+| Review | /address-pr-feedback, /arcade-collab, /pr-review, /pr-visual | User prepares a PR, receives review feedback, or needs visual diff understanding |
+| Documentation | /fix-mermaid, /generate-user-docs, /markdown-preview, /mermaid, /project-birds-eye-view, /write-content | User writes, updates, or previews docs, diagrams, or project overviews |
+| Knowledge | /guide, /knowledge-build, /knowledge-load, /self-update | User needs codebase context, KB is stale, or wants KB templates |
+| Strategy | /analyse-security, /deep-research, /strategize | User faces architectural decisions, security concerns, or needs deep research |
+| Planning | /blueprint, /blueprint-archive, /blueprint-audit | User plans a project, audits a PRD, or manages blueprint lifecycle |
+| Prompt | /create-prompt, /prompt-writer | User authors, rewrites, or evaluates agent prompts |
+
+### Suggestion Rules
+- Limit to 1 suggestion per turn. Format: skill name, one sentence why, offer to run.
+- Do not re-suggest a skill the user declined this session.
+- Do not suggest while an rp1 workflow is already running.
+- Only suggest when there is a clear match to the user's current activity.
+- For deeper questions about rp1, suggest the user invoke /guide.
+<!-- rp1:end:v0.7.1 -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,49 @@
 @./AGENTS.md
+
+<!-- rp1:start:v0.7.1 -->
+## rp1 Knowledge Base
+
+**Use Progressive Disclosure Pattern**
+
+Location: `.rp1/context/`
+
+Files:
+- index.md (always load first)
+- architecture.md
+- modules.md
+- patterns.md
+- concept_map.md
+
+Loading rules:
+1. Always read index.md first.
+2. Then load based on task type:
+   - Code review: patterns.md
+   - Bug investigation: architecture.md, modules.md
+   - Feature work: modules.md, patterns.md
+   - Strategic or system-wide analysis: all files
+
+## rp1 Skill Awareness
+
+You have access to rp1 skills. When you notice the user working on a task
+that an rp1 skill addresses, briefly suggest it.
+
+### Skill Categories
+| Category | Skills | Suggest When |
+|----------|--------|--------------|
+| Development | /task, /bootstrap, /build, /build-fast, /feature-archive, /feature-edit, /feature-unarchive, /phase-plan, /speedrun | User starts a new feature, describes a change, or needs to scaffold a project |
+| Investigation | /code-investigate, /validate-hypothesis | User is debugging, examining errors, or testing a design hypothesis |
+| Quality | /code-comments, /code-audit, /code-check, /code-clean-comments | User finishes implementation and needs hygiene checks, audits, or comment cleanup |
+| Review | /address-pr-feedback, /arcade-collab, /pr-review, /pr-visual | User prepares a PR, receives review feedback, or needs visual diff understanding |
+| Documentation | /fix-mermaid, /generate-user-docs, /markdown-preview, /mermaid, /project-birds-eye-view, /write-content | User writes, updates, or previews docs, diagrams, or project overviews |
+| Knowledge | /guide, /knowledge-build, /knowledge-load, /self-update | User needs codebase context, KB is stale, or wants KB templates |
+| Strategy | /analyse-security, /deep-research, /strategize | User faces architectural decisions, security concerns, or needs deep research |
+| Planning | /blueprint, /blueprint-archive, /blueprint-audit | User plans a project, audits a PRD, or manages blueprint lifecycle |
+| Prompt | /create-prompt, /prompt-writer | User authors, rewrites, or evaluates agent prompts |
+
+### Suggestion Rules
+- Limit to 1 suggestion per turn. Format: skill name, one sentence why, offer to run.
+- Do not re-suggest a skill the user declined this session.
+- Do not suggest while an rp1 workflow is already running.
+- Only suggest when there is a clear match to the user's current activity.
+- For deeper questions about rp1, suggest the user invoke /guide.
+<!-- rp1:end:v0.7.1 -->

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -353,13 +353,42 @@ async function initializeAcpSession(
   return result.right;
 }
 
-function setupAcpCommunication(
+/**
+ * Register forwarders for `SessionManager`'s history callbacks. MUST run
+ * BEFORE the first `initializeAcpSession` so the `session/load` replay
+ * triggered during startup actually reaches the webview. When the restart
+ * flow silently reattaches an existing session the webview already holds the
+ * live transcript; `suppressHistoryReplay.current = true` skips forwarding in
+ * that window so we don't overwrite live timestamps with "Earlier" labels.
+ */
+function registerHistoryForwarding(
+  provider: WebviewProvider,
+  manager: SessionManager,
+  suppressHistoryReplay: { current: boolean }
+): void {
+  manager.onHistoryMessage(message => {
+    if (suppressHistoryReplay.current) return;
+    provider.postMessage(createHistoryMessage(message));
+  });
+
+  manager.onHistoryComplete((sessionId, messageCount) => {
+    if (suppressHistoryReplay.current) return;
+    provider.postMessage(createHistoryCompleteMessage(sessionId, messageCount));
+  });
+}
+
+/**
+ * Register the webview-side message handlers (send, cancel, session CRUD)
+ * against the ACP subprocess. Runs AFTER `initializeAcpSession` succeeds;
+ * deliberately split from history-forwarding registration so the mock
+ * fallback path can run without also receiving ACP send events.
+ */
+function setupAcpWebviewHandlers(
   provider: WebviewProvider,
   subprocess: SubprocessManager,
   manager: SessionManager,
   log: Logger,
-  responseIdRef: { current: string | null },
-  suppressHistoryReplay: { current: boolean }
+  responseIdRef: { current: string | null }
 ): void {
   const getActiveSessionId = (): string | null => {
     return manager.getActiveSessionId();
@@ -375,22 +404,6 @@ function setupAcpCommunication(
     }
     return op(clientResult.right);
   };
-
-  // When the restart flow silently reattaches an existing session the server
-  // still streams the full transcript, but the webview already holds that
-  // transcript as live messages -- forwarding the replay would just overwrite
-  // live timestamps with "Earlier" labels. Skip forwarding while the
-  // suppression flag is set; the reinit code clears it once its session/load
-  // has completed.
-  manager.onHistoryMessage(message => {
-    if (suppressHistoryReplay.current) return;
-    provider.postMessage(createHistoryMessage(message));
-  });
-
-  manager.onHistoryComplete((sessionId, messageCount) => {
-    if (suppressHistoryReplay.current) return;
-    provider.postMessage(createHistoryCompleteMessage(sessionId, messageCount));
-  });
 
   provider.onMessage(message => {
     if (isSendMessageMessage(message)) {
@@ -622,7 +635,8 @@ function subscribeSessionUpdates(
   subprocess: SubprocessManager,
   responseIdRef: { current: string | null },
   log: Logger,
-  lastSubscribedClient: { current: JsonRpcClient | null }
+  lastSubscribedClient: { current: JsonRpcClient | null },
+  suppressHistoryReplay: { current: boolean }
 ): void {
   const clientResult = subprocess.getClient();
   if (E.isLeft(clientResult)) {
@@ -644,6 +658,11 @@ function subscribeSessionUpdates(
       const responseId = responseIdRef.current;
 
       if (sessionUpdate === 'agent_message_chunk' && responseId && content?.type === 'text') {
+        // Guard against the restart race: while a session/load replay is in
+        // flight (`suppressHistoryReplay === true`), historical chunks must
+        // not be appended to an in-flight live assistant response. The load
+        // branch of SessionManager handles those chunks as history itself.
+        if (suppressHistoryReplay.current) return;
         provider.postMessage(createStreamTokenMessage(responseId, content.text, false));
       }
     }
@@ -815,7 +834,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   subprocessManager.onStatusChange(status => {
     logger?.info(`Subprocess status: ${status}`);
-    webviewProvider?.updateStatus(status);
+
+    // Never broadcast RUNNING from here: the webview must not enable send
+    // until the ACP handshake (initial or restart) has completed, otherwise
+    // the first prompt races and fails with Session not found. Both the
+    // initial activation path and the restart path below emit RUNNING
+    // inline once the handshake finishes. Other statuses (STARTING, STOPPED,
+    // ERROR) are forwarded immediately so the webview can reflect them.
+    if (status !== ProcessStatus.RUNNING) {
+      webviewProvider?.updateStatus(status);
+    }
+
+    // If the subprocess exited (restart or crash) mid-generation, close out
+    // any streaming assistant message and drop the in-flight responseId.
+    // Otherwise the webview spinner spins forever AND the next session/update
+    // from either session/load replay or the new prompt would attach to the
+    // stale id.
+    if (status !== ProcessStatus.RUNNING && responseIdRef.current && webviewProvider) {
+      webviewProvider.postMessage(createGenerationCompleteMessage(responseIdRef.current));
+      responseIdRef.current = null;
+    }
 
     if (status === ProcessStatus.ERROR) {
       vscode.window.showWarningMessage(
@@ -834,7 +872,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         subprocessManager,
         responseIdRef,
         acpLogger,
-        lastSubscribedClient
+        lastSubscribedClient,
+        suppressHistoryReplay
       );
 
       if (acpInitialized && sessionManager) {
@@ -848,9 +887,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           getWorkspaceFolder(),
           acpLogger,
           suppressHistoryReplay
-        ).catch(err => {
-          acpLogger.error('ACP re-init after restart threw:', err);
-        });
+        )
+          .then(() => {
+            // Safe to open the gate now: session is attached server-side.
+            provider.updateStatus(ProcessStatus.RUNNING);
+          })
+          .catch(err => {
+            acpLogger.error('ACP re-init after restart threw:', err);
+            provider.updateStatus(ProcessStatus.ERROR);
+          });
       }
     }
   });
@@ -869,31 +914,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     logger.info('[Mock] Mock streaming enabled (subprocess failed to start)');
   } else {
     logger.info('Subprocess started successfully');
-    webviewProvider.updateStatus(ProcessStatus.RUNNING);
 
     const clientResult = subprocessManager.getClient();
     if (E.isRight(clientResult)) {
       const client = clientResult.right;
 
-      // Wire listeners BEFORE the initial handshake. `initializeAcpSession`
-      // calls `session/load`, which replays the full transcript through
-      // `manager.onHistoryMessage` -- if no listener is registered yet those
-      // chunks are dropped and the webview ends up with an empty chat that
-      // secretly points at the restored session on the server side.
-      setupAcpCommunication(
-        webviewProvider,
-        subprocessManager,
-        sessionManager,
-        acpLogger,
-        responseIdRef,
-        suppressHistoryReplay
-      );
+      // Register the history forwarders and session/update subscriber BEFORE
+      // the handshake. `initializeAcpSession` calls `session/load`, which
+      // replays the full transcript through `manager.onHistoryMessage` -- if
+      // no listener is registered yet those chunks are dropped and the
+      // webview ends up with an empty chat that secretly points at the
+      // restored session on the server side. The webview-side message
+      // handlers (send / cancel / session CRUD) are deliberately deferred
+      // until AFTER the handshake succeeds so the mock fallback path below
+      // doesn't run alongside a duplicate ACP send handler.
+      registerHistoryForwarding(webviewProvider, sessionManager, suppressHistoryReplay);
       subscribeSessionUpdates(
         webviewProvider,
         subprocessManager,
         responseIdRef,
         acpLogger,
-        lastSubscribedClient
+        lastSubscribedClient,
+        suppressHistoryReplay
       );
 
       const session = await initializeAcpSession(
@@ -904,6 +946,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       );
 
       if (session) {
+        setupAcpWebviewHandlers(
+          webviewProvider,
+          subprocessManager,
+          sessionManager,
+          acpLogger,
+          responseIdRef
+        );
         // Tell the webview which session is now active so its header / session
         // list reflects the restored session instead of showing "New Session"
         // for what is actually a pre-existing conversation on the server.
@@ -911,13 +960,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           createSessionsListMessage(sessionManager.getSessions(), session.sessionId)
         );
         acpInitialized = true;
+        // Initial activation: broadcast RUNNING now that the handshake is
+        // complete. Subsequent RUNNING transitions go through the restart
+        // deferral path above.
+        webviewProvider.updateStatus(ProcessStatus.RUNNING);
         logger.info('ACP communication enabled');
       } else {
         setupMockStreaming(webviewProvider, logger.child('Mock'));
+        // Mock has its own send handler; broadcast RUNNING so the webview
+        // enables input.
+        webviewProvider.updateStatus(ProcessStatus.RUNNING);
         logger.info('[Mock] Mock streaming enabled (session initialization failed)');
       }
     } else {
       setupMockStreaming(webviewProvider, logger.child('Mock'));
+      webviewProvider.updateStatus(ProcessStatus.RUNNING);
       logger.info('[Mock] Mock streaming enabled (no client available)');
     }
   }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -355,32 +355,25 @@ async function initializeAcpSession(
 
 function setupAcpCommunication(
   provider: WebviewProvider,
-  client: JsonRpcClient,
+  subprocess: SubprocessManager,
   manager: SessionManager,
-  log: Logger
+  log: Logger,
+  responseIdRef: { current: string | null }
 ): void {
-  let currentResponseId: string | null = null;
-
   const getActiveSessionId = (): string | null => {
     return manager.getActiveSessionId();
   };
 
-  client.onNotification((notification: JsonRpcNotification) => {
-    const method = notification.method;
-    const params = notification.params as AcpSessionUpdateParams | undefined;
-
-    if (method === 'session/update' && params?.update) {
-      const { sessionUpdate, content } = params.update;
-
-      if (
-        sessionUpdate === 'agent_message_chunk' &&
-        currentResponseId &&
-        content?.type === 'text'
-      ) {
-        provider.postMessage(createStreamTokenMessage(currentResponseId, content.text, false));
-      }
+  // Resolve the current client lazily on every use so that a restart
+  // (which creates a fresh JsonRpcClient inside SubprocessManager) is
+  // picked up automatically instead of binding to a stale closure.
+  const withClient = <T>(op: (client: JsonRpcClient) => T, onMissing: (err: unknown) => T): T => {
+    const clientResult = subprocess.getClient();
+    if (E.isLeft(clientResult)) {
+      return onMissing(clientResult.left);
     }
-  });
+    return op(clientResult.right);
+  };
 
   manager.onHistoryMessage(message => {
     provider.postMessage(createHistoryMessage(message));
@@ -393,7 +386,7 @@ function setupAcpCommunication(
   provider.onMessage(message => {
     if (isSendMessageMessage(message)) {
       const { content, responseId, contextChips } = message.payload;
-      currentResponseId = responseId;
+      responseIdRef.current = responseId;
       const activeSessionId = getActiveSessionId();
 
       if (!activeSessionId) {
@@ -418,10 +411,35 @@ function setupAcpCommunication(
         // Build prompt content blocks with resource links for context
         const promptBlocks = await buildPromptBlocks(content, contextChips, log);
 
-        const result = await client.request<AcpPromptResponse>('session/prompt', {
-          sessionId: activeSessionId,
-          prompt: promptBlocks,
-        })();
+        const clientResult = subprocess.getClient();
+        if (E.isLeft(clientResult)) {
+          log.error('No ACP client available:', clientResult.left);
+          provider.postMessage(
+            createErrorMessage(
+              'Message Send Failed',
+              'Goose subprocess is not running. Try "Goose: Restart".',
+              { label: 'View Logs', command: 'goose.showLogs' }
+            )
+          );
+          if (responseIdRef.current) {
+            provider.postMessage(createGenerationCancelledMessage(responseIdRef.current));
+            responseIdRef.current = null;
+          }
+          return;
+        }
+
+        // `session/prompt` streams the agent's full reply and can legitimately
+        // take far longer than the client's default request timeout. Pass
+        // `timeoutMs: null` so the client-side timer never fires; cancellation
+        // still flows through `session/cancel`.
+        const result = await clientResult.right.request<AcpPromptResponse>(
+          'session/prompt',
+          {
+            sessionId: activeSessionId,
+            prompt: promptBlocks,
+          },
+          { timeoutMs: null }
+        )();
 
         if (E.isLeft(result)) {
           log.error('ACP request failed:', result.left);
@@ -432,19 +450,19 @@ function setupAcpCommunication(
               { label: 'View Logs', command: 'goose.showLogs' }
             )
           );
-          if (currentResponseId) {
-            provider.postMessage(createGenerationCancelledMessage(currentResponseId));
-            currentResponseId = null;
+          if (responseIdRef.current) {
+            provider.postMessage(createGenerationCancelledMessage(responseIdRef.current));
+            responseIdRef.current = null;
           }
         } else {
           log.info(`Generation completed with stopReason: ${result.right.stopReason}`);
-          if (currentResponseId) {
+          if (responseIdRef.current) {
             if (result.right.stopReason === 'cancelled') {
-              provider.postMessage(createGenerationCancelledMessage(currentResponseId));
+              provider.postMessage(createGenerationCancelledMessage(responseIdRef.current));
             } else {
-              provider.postMessage(createGenerationCompleteMessage(currentResponseId));
+              provider.postMessage(createGenerationCompleteMessage(responseIdRef.current));
             }
-            currentResponseId = null;
+            responseIdRef.current = null;
           }
         }
       };
@@ -456,10 +474,17 @@ function setupAcpCommunication(
       const activeSessionId = getActiveSessionId();
       if (activeSessionId) {
         log.info('Sending cancel request to ACP');
-        const cancelResult = client.notify('session/cancel', { sessionId: activeSessionId });
-        if (E.isLeft(cancelResult)) {
-          log.error('Failed to send cancel notification:', cancelResult.left);
-        }
+        withClient(
+          client => {
+            const cancelResult = client.notify('session/cancel', { sessionId: activeSessionId });
+            if (E.isLeft(cancelResult)) {
+              log.error('Failed to send cancel notification:', cancelResult.left);
+            }
+          },
+          err => {
+            log.warn('Cannot cancel: no ACP client available', err);
+          }
+        );
       }
     }
 
@@ -515,6 +540,48 @@ function setupAcpCommunication(
   });
 
   log.info('ACP communication handler registered');
+}
+
+/**
+ * Attach the `session/update` notification handler to the current JsonRpcClient.
+ *
+ * Called once on first successful activation and again on every subsequent
+ * `ProcessStatus.RUNNING` transition (e.g. after `Goose: Restart`). A guard
+ * ref tracks the last client we subscribed to so we never double-subscribe.
+ */
+function subscribeSessionUpdates(
+  provider: WebviewProvider,
+  subprocess: SubprocessManager,
+  responseIdRef: { current: string | null },
+  log: Logger,
+  lastSubscribedClient: { current: JsonRpcClient | null }
+): void {
+  const clientResult = subprocess.getClient();
+  if (E.isLeft(clientResult)) {
+    log.debug('Skipping session/update subscription: no client available');
+    return;
+  }
+  const client = clientResult.right;
+  if (lastSubscribedClient.current === client) {
+    return;
+  }
+  lastSubscribedClient.current = client;
+
+  client.onNotification((notification: JsonRpcNotification) => {
+    const method = notification.method;
+    const params = notification.params as AcpSessionUpdateParams | undefined;
+
+    if (method === 'session/update' && params?.update) {
+      const { sessionUpdate, content } = params.update;
+      const responseId = responseIdRef.current;
+
+      if (sessionUpdate === 'agent_message_chunk' && responseId && content?.type === 'text') {
+        provider.postMessage(createStreamTokenMessage(responseId, content.text, false));
+      }
+    }
+  });
+
+  log.info('Subscribed to session/update notifications');
 }
 
 function getWorkspaceFolder(): string {
@@ -661,6 +728,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     workingDirectory: getWorkspaceFolder(),
   });
 
+  // Shared refs so the `session/update` subscriber and the webview message
+  // handler observe the same streaming response id, and so we never
+  // double-subscribe to the same JsonRpcClient instance across restarts.
+  const responseIdRef: { current: string | null } = { current: null };
+  const lastSubscribedClient: { current: JsonRpcClient | null } = { current: null };
+
+  const acpLogger = logger.child('ACP');
+
   subprocessManager.onStatusChange(status => {
     logger?.info(`Subprocess status: ${status}`);
     webviewProvider?.updateStatus(status);
@@ -668,6 +743,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     if (status === ProcessStatus.ERROR) {
       vscode.window.showWarningMessage(
         'Goose subprocess crashed. Use "Goose: Restart" to reconnect.'
+      );
+    }
+
+    // On every transition into RUNNING (initial start + every restart), attach
+    // the `session/update` notification handler to the newly-created client.
+    // The guard inside `subscribeSessionUpdates` prevents re-subscribing to a
+    // client we have already bound to (e.g. the initial activation pathway
+    // below will have already subscribed to the first client by the time the
+    // status listener fires).
+    if (status === ProcessStatus.RUNNING && webviewProvider && subprocessManager) {
+      subscribeSessionUpdates(
+        webviewProvider,
+        subprocessManager,
+        responseIdRef,
+        acpLogger,
+        lastSubscribedClient
       );
     }
   });
@@ -695,11 +786,24 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         client,
         getWorkspaceFolder(),
         sessionManager,
-        logger.child('ACP')
+        acpLogger
       );
 
       if (session) {
-        setupAcpCommunication(webviewProvider, client, sessionManager, logger.child('ACP'));
+        setupAcpCommunication(
+          webviewProvider,
+          subprocessManager,
+          sessionManager,
+          acpLogger,
+          responseIdRef
+        );
+        subscribeSessionUpdates(
+          webviewProvider,
+          subprocessManager,
+          responseIdRef,
+          acpLogger,
+          lastSubscribedClient
+        );
         logger.info('ACP communication enabled');
       } else {
         setupMockStreaming(webviewProvider, logger.child('Mock'));

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -874,6 +874,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const clientResult = subprocessManager.getClient();
     if (E.isRight(clientResult)) {
       const client = clientResult.right;
+
+      // Wire listeners BEFORE the initial handshake. `initializeAcpSession`
+      // calls `session/load`, which replays the full transcript through
+      // `manager.onHistoryMessage` -- if no listener is registered yet those
+      // chunks are dropped and the webview ends up with an empty chat that
+      // secretly points at the restored session on the server side.
+      setupAcpCommunication(
+        webviewProvider,
+        subprocessManager,
+        sessionManager,
+        acpLogger,
+        responseIdRef,
+        suppressHistoryReplay
+      );
+      subscribeSessionUpdates(
+        webviewProvider,
+        subprocessManager,
+        responseIdRef,
+        acpLogger,
+        lastSubscribedClient
+      );
+
       const session = await initializeAcpSession(
         client,
         getWorkspaceFolder(),
@@ -882,20 +904,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       );
 
       if (session) {
-        setupAcpCommunication(
-          webviewProvider,
-          subprocessManager,
-          sessionManager,
-          acpLogger,
-          responseIdRef,
-          suppressHistoryReplay
-        );
-        subscribeSessionUpdates(
-          webviewProvider,
-          subprocessManager,
-          responseIdRef,
-          acpLogger,
-          lastSubscribedClient
+        // Tell the webview which session is now active so its header / session
+        // list reflects the restored session instead of showing "New Session"
+        // for what is actually a pre-existing conversation on the server.
+        webviewProvider.postMessage(
+          createSessionsListMessage(sessionManager.getSessions(), session.sessionId)
         );
         acpInitialized = true;
         logger.info('ACP communication enabled');

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -436,6 +436,9 @@ function setupAcpWebviewHandlers(
         const clientResult = subprocess.getClient();
         if (E.isLeft(clientResult)) {
           log.error('No ACP client available:', clientResult.left);
+          // The webview's ADD_ERROR_MESSAGE reducer cleans up the optimistic
+          // assistant placeholder, so we don't need to also post
+          // GENERATION_COMPLETE here (which would leave a blank bubble).
           provider.postMessage(
             createErrorMessage(
               'Message Send Failed',
@@ -443,10 +446,7 @@ function setupAcpWebviewHandlers(
               { label: 'View Logs', command: 'goose.showLogs' }
             )
           );
-          if (responseIdRef.current) {
-            provider.postMessage(createGenerationCompleteMessage(responseIdRef.current));
-            responseIdRef.current = null;
-          }
+          responseIdRef.current = null;
           return;
         }
 
@@ -465,6 +465,10 @@ function setupAcpWebviewHandlers(
 
         if (E.isLeft(result)) {
           log.error('ACP request failed:', result.left);
+          // The webview's ADD_ERROR_MESSAGE reducer drops the empty assistant
+          // placeholder (or marks a partially-streamed one complete) and
+          // resets isGenerating. No GENERATION_COMPLETE needed -- sending
+          // both would leave a blank bubble above the error row.
           provider.postMessage(
             createErrorMessage(
               'Message Send Failed',
@@ -472,14 +476,7 @@ function setupAcpWebviewHandlers(
               { label: 'View Logs', command: 'goose.showLogs' }
             )
           );
-          if (responseIdRef.current) {
-            // A JSON-RPC failure is not a user- or agent-initiated cancellation.
-            // Clear the streaming state so the input unlocks, but let the error
-            // banner above carry the signal -- the `(cancelled)` label is
-            // reserved for real cancels (stop button -> stopReason: 'cancelled').
-            provider.postMessage(createGenerationCompleteMessage(responseIdRef.current));
-            responseIdRef.current = null;
-          }
+          responseIdRef.current = null;
         } else {
           log.info(`Generation completed with stopReason: ${result.right.stopReason}`);
           if (responseIdRef.current) {
@@ -845,15 +842,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       webviewProvider?.updateStatus(status);
     }
 
-    // If the subprocess exited (restart or crash) mid-generation, close out
-    // any streaming assistant message and drop the in-flight responseId.
-    // Otherwise the webview spinner spins forever AND the next session/update
-    // from either session/load replay or the new prompt would attach to the
-    // stale id.
-    if (status !== ProcessStatus.RUNNING && responseIdRef.current && webviewProvider) {
-      webviewProvider.postMessage(createGenerationCompleteMessage(responseIdRef.current));
-      responseIdRef.current = null;
-    }
+    // Note: we deliberately do NOT close out the streaming assistant bubble
+    // or null `responseIdRef` here. When the subprocess dies mid-generation,
+    // `JsonRpcClient.dispose()` rejects every pending request; the
+    // `sendRequest` error path then runs, posts an `ErrorMessage`, and
+    // `ADD_ERROR_MESSAGE` in the webview reducer removes the optimistic
+    // placeholder. Handling the cleanup from two places would race to post
+    // both a COMPLETE and an ERROR for the same bubble.
 
     if (status === ProcessStatus.ERROR) {
       vscode.window.showWarningMessage(

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -422,7 +422,7 @@ function setupAcpCommunication(
             )
           );
           if (responseIdRef.current) {
-            provider.postMessage(createGenerationCancelledMessage(responseIdRef.current));
+            provider.postMessage(createGenerationCompleteMessage(responseIdRef.current));
             responseIdRef.current = null;
           }
           return;
@@ -451,7 +451,11 @@ function setupAcpCommunication(
             )
           );
           if (responseIdRef.current) {
-            provider.postMessage(createGenerationCancelledMessage(responseIdRef.current));
+            // A JSON-RPC failure is not a user- or agent-initiated cancellation.
+            // Clear the streaming state so the input unlocks, but let the error
+            // banner above carry the signal -- the `(cancelled)` label is
+            // reserved for real cancels (stop button -> stopReason: 'cancelled').
+            provider.postMessage(createGenerationCompleteMessage(responseIdRef.current));
             responseIdRef.current = null;
           }
         } else {
@@ -540,6 +544,43 @@ function setupAcpCommunication(
   });
 
   log.info('ACP communication handler registered');
+}
+
+/**
+ * Re-run the ACP handshake against the current subprocess client and reconcile
+ * session state. Called on every `ProcessStatus.RUNNING` transition AFTER the
+ * initial activation (e.g. on `Goose: Restart`). The fresh `goose acp` process
+ * does not know any of the previously-issued session ids, so `initializeAcpSession`
+ * will typically fall through to `session/new`; if that happens we notify the
+ * webview so the new session id is picked up for subsequent prompts.
+ */
+async function reinitializeAcpOnRestart(
+  provider: WebviewProvider,
+  subprocess: SubprocessManager,
+  manager: SessionManager,
+  workingDirectory: string,
+  log: Logger
+): Promise<void> {
+  const clientResult = subprocess.getClient();
+  if (E.isLeft(clientResult)) {
+    log.debug('Skipping ACP re-init: no client available');
+    return;
+  }
+
+  const previousSessionId = manager.getActiveSessionId();
+  const session = await initializeAcpSession(clientResult.right, workingDirectory, manager, log);
+
+  if (!session) {
+    log.warn('ACP re-init after restart failed to establish a session');
+    return;
+  }
+
+  const isFreshSession = session.sessionId !== previousSessionId;
+  if (isFreshSession) {
+    log.info(`ACP re-init created fresh session ${session.sessionId} after restart`);
+    provider.postMessage(createSessionCreatedMessage(session));
+  }
+  provider.postMessage(createSessionsListMessage(manager.getSessions(), session.sessionId));
 }
 
 /**
@@ -733,6 +774,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // double-subscribe to the same JsonRpcClient instance across restarts.
   const responseIdRef: { current: string | null } = { current: null };
   const lastSubscribedClient: { current: JsonRpcClient | null } = { current: null };
+  // Tracks whether the initial ACP handshake has completed. Post-restart
+  // RUNNING transitions use this to decide whether to re-run the handshake
+  // against the fresh subprocess (skip on the very first RUNNING because the
+  // activation path below runs `initializeAcpSession` inline).
+  let acpInitialized = false;
 
   const acpLogger = logger.child('ACP');
 
@@ -747,11 +793,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
 
     // On every transition into RUNNING (initial start + every restart), attach
-    // the `session/update` notification handler to the newly-created client.
-    // The guard inside `subscribeSessionUpdates` prevents re-subscribing to a
-    // client we have already bound to (e.g. the initial activation pathway
-    // below will have already subscribed to the first client by the time the
-    // status listener fires).
+    // the `session/update` notification handler to the newly-created client
+    // and, if this is a RE-start (initial handshake already done), re-run the
+    // ACP handshake so the new subprocess has a live session -- otherwise the
+    // first prompt after restart fails with `-32002 Session not found`.
     if (status === ProcessStatus.RUNNING && webviewProvider && subprocessManager) {
       subscribeSessionUpdates(
         webviewProvider,
@@ -760,6 +805,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         acpLogger,
         lastSubscribedClient
       );
+
+      if (acpInitialized && sessionManager) {
+        const provider = webviewProvider;
+        const subprocess = subprocessManager;
+        const manager = sessionManager;
+        void reinitializeAcpOnRestart(
+          provider,
+          subprocess,
+          manager,
+          getWorkspaceFolder(),
+          acpLogger
+        ).catch(err => {
+          acpLogger.error('ACP re-init after restart threw:', err);
+        });
+      }
     }
   });
 
@@ -804,6 +864,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           acpLogger,
           lastSubscribedClient
         );
+        acpInitialized = true;
         logger.info('ACP communication enabled');
       } else {
         setupMockStreaming(webviewProvider, logger.child('Mock'));

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -358,7 +358,8 @@ function setupAcpCommunication(
   subprocess: SubprocessManager,
   manager: SessionManager,
   log: Logger,
-  responseIdRef: { current: string | null }
+  responseIdRef: { current: string | null },
+  suppressHistoryReplay: { current: boolean }
 ): void {
   const getActiveSessionId = (): string | null => {
     return manager.getActiveSessionId();
@@ -375,11 +376,19 @@ function setupAcpCommunication(
     return op(clientResult.right);
   };
 
+  // When the restart flow silently reattaches an existing session the server
+  // still streams the full transcript, but the webview already holds that
+  // transcript as live messages -- forwarding the replay would just overwrite
+  // live timestamps with "Earlier" labels. Skip forwarding while the
+  // suppression flag is set; the reinit code clears it once its session/load
+  // has completed.
   manager.onHistoryMessage(message => {
+    if (suppressHistoryReplay.current) return;
     provider.postMessage(createHistoryMessage(message));
   });
 
   manager.onHistoryComplete((sessionId, messageCount) => {
+    if (suppressHistoryReplay.current) return;
     provider.postMessage(createHistoryCompleteMessage(sessionId, messageCount));
   });
 
@@ -559,7 +568,8 @@ async function reinitializeAcpOnRestart(
   subprocess: SubprocessManager,
   manager: SessionManager,
   workingDirectory: string,
-  log: Logger
+  log: Logger,
+  suppressHistoryReplay: { current: boolean }
 ): Promise<void> {
   const clientResult = subprocess.getClient();
   if (E.isLeft(clientResult)) {
@@ -567,17 +577,20 @@ async function reinitializeAcpOnRestart(
     return;
   }
 
-  // The webview still holds the live messages from before the restart. If the
-  // fresh subprocess can `session/load` the prior session, history replay
-  // would append every historical message on top of those live copies and
-  // show each turn twice. If it falls through to `session/new`, the live
-  // messages belong to a dead session id and are no longer meaningful.
-  // Either way, clear the transcript before the handshake so the post-restart
-  // view reflects the true server-side state.
-  provider.postMessage(createChatHistoryMessage([]));
-
+  // Suppress history forwarding for the duration of the handshake. If the
+  // fresh subprocess can `session/load` the prior session, we want the
+  // webview to keep its live transcript as-is (otherwise every message would
+  // re-render as "Earlier"). Only clear + repopulate if we fall through to
+  // `session/new`, because then the webview's live messages belong to a
+  // session id the new subprocess no longer knows about.
   const previousSessionId = manager.getActiveSessionId();
-  const session = await initializeAcpSession(clientResult.right, workingDirectory, manager, log);
+  suppressHistoryReplay.current = true;
+  let session: SessionEntry | null = null;
+  try {
+    session = await initializeAcpSession(clientResult.right, workingDirectory, manager, log);
+  } finally {
+    suppressHistoryReplay.current = false;
+  }
 
   if (!session) {
     log.warn('ACP re-init after restart failed to establish a session');
@@ -587,7 +600,12 @@ async function reinitializeAcpOnRestart(
   const isFreshSession = session.sessionId !== previousSessionId;
   if (isFreshSession) {
     log.info(`ACP re-init created fresh session ${session.sessionId} after restart`);
+    // The webview's live messages belonged to the dead session id; replace
+    // them with an empty transcript so the UI matches the new server state.
+    provider.postMessage(createChatHistoryMessage([]));
     provider.postMessage(createSessionCreatedMessage(session));
+  } else {
+    log.info(`ACP re-init silently reattached session ${session.sessionId} after restart`);
   }
   provider.postMessage(createSessionsListMessage(manager.getSessions(), session.sessionId));
 }
@@ -783,6 +801,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // double-subscribe to the same JsonRpcClient instance across restarts.
   const responseIdRef: { current: string | null } = { current: null };
   const lastSubscribedClient: { current: JsonRpcClient | null } = { current: null };
+  // When true, history messages emitted by `SessionManager.loadSession` are
+  // NOT forwarded to the webview. Used by the restart flow to silently
+  // reattach an existing session without re-rendering the live transcript.
+  const suppressHistoryReplay: { current: boolean } = { current: false };
   // Tracks whether the initial ACP handshake has completed. Post-restart
   // RUNNING transitions use this to decide whether to re-run the handshake
   // against the fresh subprocess (skip on the very first RUNNING because the
@@ -824,7 +846,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           subprocess,
           manager,
           getWorkspaceFolder(),
-          acpLogger
+          acpLogger,
+          suppressHistoryReplay
         ).catch(err => {
           acpLogger.error('ACP re-init after restart threw:', err);
         });
@@ -864,7 +887,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           subprocessManager,
           sessionManager,
           acpLogger,
-          responseIdRef
+          responseIdRef,
+          suppressHistoryReplay
         );
         subscribeSessionUpdates(
           webviewProvider,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -567,6 +567,15 @@ async function reinitializeAcpOnRestart(
     return;
   }
 
+  // The webview still holds the live messages from before the restart. If the
+  // fresh subprocess can `session/load` the prior session, history replay
+  // would append every historical message on top of those live copies and
+  // show each turn twice. If it falls through to `session/new`, the live
+  // messages belong to a dead session id and are no longer meaningful.
+  // Either way, clear the transcript before the handshake so the post-restart
+  // view reflects the true server-side state.
+  provider.postMessage(createChatHistoryMessage([]));
+
   const previousSessionId = manager.getActiveSessionId();
   const session = await initializeAcpSession(clientResult.right, workingDirectory, manager, log);
 

--- a/src/extension/jsonRpcClient.test.ts
+++ b/src/extension/jsonRpcClient.test.ts
@@ -176,6 +176,24 @@ describe('createJsonRpcClient', () => {
       }
     });
 
+    test('request with timeoutMs: undefined inherits the client default', async () => {
+      // Default client timeout for this describe() is 1000ms. Explicit
+      // `undefined` must behave exactly like an omitted option and time out.
+      const shortTimeoutConfig: JsonRpcClientConfig = {
+        stdin: mockStreams.stdin,
+        stdout: mockStreams.stdout,
+        logger,
+        timeoutMs: 50,
+      };
+      const c = createJsonRpcClient(shortTimeoutConfig);
+      const result = await c.request('slow.method', undefined, { timeoutMs: undefined })();
+
+      expect(E.isLeft(result)).toBe(true);
+      if (E.isLeft(result)) {
+        expect(result.left._tag).toBe('JsonRpcTimeoutError');
+      }
+    });
+
     test('request with timeoutMs: null never times out', async () => {
       // Default client timeout for this describe() is 1000ms. A response pushed
       // after 1500ms would normally fire the timeout timer; with `timeoutMs: null`

--- a/src/extension/jsonRpcClient.test.ts
+++ b/src/extension/jsonRpcClient.test.ts
@@ -176,6 +176,29 @@ describe('createJsonRpcClient', () => {
       }
     });
 
+    test('request with timeoutMs: null never times out', async () => {
+      // Default client timeout for this describe() is 1000ms. A response pushed
+      // after 1500ms would normally fire the timeout timer; with `timeoutMs: null`
+      // the timer must not be scheduled at all.
+      const requestTask = client.request<string>('long.stream', undefined, { timeoutMs: null });
+      const requestPromise = requestTask();
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(mockStreams.written.length).toBe(1);
+
+      // Wait past the default timeout before responding.
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
+      mockStreams.pushResponse(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 'late-but-valid' }));
+
+      const result = await requestPromise;
+
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right).toBe('late-but-valid');
+      }
+    });
+
     test('matches responses to correct pending requests', async () => {
       const request1 = client.request<string>('method1');
       const request2 = client.request<string>('method2');

--- a/src/extension/jsonRpcClient.ts
+++ b/src/extension/jsonRpcClient.ts
@@ -159,12 +159,13 @@ export function createJsonRpcClient(config: JsonRpcClientConfig): JsonRpcClient 
           ...(params !== undefined && { params }),
         };
 
-        // Resolve effective timeout:
-        //   - explicit `null` -> no timer (request never times out client-side)
-        //   - explicit number -> per-call override
-        //   - omitted         -> fall back to the client default
-        const effectiveTimeout =
-          options && 'timeoutMs' in options ? (options.timeoutMs ?? null) : timeoutMs;
+        // Resolve effective timeout per the JsonRpcRequestOptions contract:
+        //   - `null`      -> no timer (request never times out client-side)
+        //   - `number`    -> per-call override
+        //   - `undefined` / omitted -> fall back to the client default
+        // Using `!== undefined` here (rather than `in` + `??`) is important:
+        // `{ timeoutMs: undefined }` must behave the same as an omitted key.
+        const effectiveTimeout = options?.timeoutMs !== undefined ? options.timeoutMs : timeoutMs;
 
         let timer: ReturnType<typeof setTimeout> | undefined;
         if (effectiveTimeout !== null) {

--- a/src/extension/jsonRpcClient.ts
+++ b/src/extension/jsonRpcClient.ts
@@ -33,17 +33,30 @@ interface PendingRequestEntry {
   readonly method: string;
   readonly resolve: (value: unknown) => void;
   readonly reject: (error: JsonRpcError | JsonRpcTimeoutError) => void;
-  readonly timer: ReturnType<typeof setTimeout>;
+  readonly timer?: ReturnType<typeof setTimeout>;
 }
 
 /** Notification callback type */
 export type NotificationCallback = (notification: JsonRpcNotification) => void;
 
+/**
+ * Per-request options.
+ *
+ * `timeoutMs` semantics:
+ *   - omitted / `undefined`: fall back to the client's constructor default
+ *   - `number`: override the default for this single request
+ *   - `null`: disable the client-side timeout for this request (never time out)
+ */
+export interface JsonRpcRequestOptions {
+  readonly timeoutMs?: number | null;
+}
+
 /** JSON-RPC client interface */
 export interface JsonRpcClient {
   readonly request: <T>(
     method: string,
-    params?: unknown
+    params?: unknown,
+    options?: JsonRpcRequestOptions
   ) => TE.TaskEither<JsonRpcError | JsonRpcTimeoutError, T>;
 
   readonly notify: (method: string, params?: unknown) => E.Either<JsonRpcParseError, void>;
@@ -75,7 +88,9 @@ export function createJsonRpcClient(config: JsonRpcClientConfig): JsonRpcClient 
       if ('id' in message && message.id !== undefined) {
         const pending = pendingRequests.get(message.id);
         if (pending) {
-          clearTimeout(pending.timer);
+          if (pending.timer !== undefined) {
+            clearTimeout(pending.timer);
+          }
           pendingRequests.delete(message.id);
 
           const response = message as JsonRpcResponse;
@@ -125,7 +140,8 @@ export function createJsonRpcClient(config: JsonRpcClientConfig): JsonRpcClient 
 
   const request = <T>(
     method: string,
-    params?: unknown
+    params?: unknown,
+    options?: JsonRpcRequestOptions
   ): TE.TaskEither<JsonRpcError | JsonRpcTimeoutError, T> => {
     return () =>
       new Promise(resolve => {
@@ -143,13 +159,23 @@ export function createJsonRpcClient(config: JsonRpcClientConfig): JsonRpcClient 
           ...(params !== undefined && { params }),
         };
 
-        const timer = setTimeout(() => {
-          const pending = pendingRequests.get(id);
-          if (pending) {
-            pendingRequests.delete(id);
-            resolve(E.left(createJsonRpcTimeoutError(method, timeoutMs, id)));
-          }
-        }, timeoutMs);
+        // Resolve effective timeout:
+        //   - explicit `null` -> no timer (request never times out client-side)
+        //   - explicit number -> per-call override
+        //   - omitted         -> fall back to the client default
+        const effectiveTimeout =
+          options && 'timeoutMs' in options ? (options.timeoutMs ?? null) : timeoutMs;
+
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        if (effectiveTimeout !== null) {
+          timer = setTimeout(() => {
+            const pending = pendingRequests.get(id);
+            if (pending) {
+              pendingRequests.delete(id);
+              resolve(E.left(createJsonRpcTimeoutError(method, effectiveTimeout, id)));
+            }
+          }, effectiveTimeout);
+        }
 
         const entry: PendingRequestEntry = {
           id,
@@ -166,7 +192,9 @@ export function createJsonRpcClient(config: JsonRpcClientConfig): JsonRpcClient 
 
         stdin.write(requestLine, err => {
           if (err) {
-            clearTimeout(timer);
+            if (timer !== undefined) {
+              clearTimeout(timer);
+            }
             pendingRequests.delete(id);
             resolve(E.left(createJsonRpcError(-32000, `Write error: ${err.message}`)));
           }
@@ -208,7 +236,9 @@ export function createJsonRpcClient(config: JsonRpcClientConfig): JsonRpcClient 
     stdout.removeListener('data', onData);
 
     for (const [id, entry] of pendingRequests) {
-      clearTimeout(entry.timer);
+      if (entry.timer !== undefined) {
+        clearTimeout(entry.timer);
+      }
       entry.reject(createJsonRpcError(-32000, 'Client disposed'));
       pendingRequests.delete(id);
     }

--- a/src/webview/hooks/useChat.ts
+++ b/src/webview/hooks/useChat.ts
@@ -5,6 +5,7 @@ import {
   createSendMessageMessage,
   createStopGenerationMessage,
   isChatHistoryMessage,
+  isErrorMessage,
   isGenerationCancelledMessage,
   isGenerationCompleteMessage,
   isHistoryMessage,
@@ -221,6 +222,15 @@ export function useChat(): UseChatReturn {
         });
       } else if (isSessionCreatedMessage(message)) {
         dispatch({ type: 'CLEAR_MESSAGES' });
+      } else if (isErrorMessage(message)) {
+        const { title, message: body } = message.payload;
+        dispatch({
+          type: 'ADD_ERROR_MESSAGE',
+          payload: {
+            id: generateId(),
+            content: body ? `${title}: ${body}` : title,
+          },
+        });
       }
     });
 

--- a/src/webview/hooks/useChat.ts
+++ b/src/webview/hooks/useChat.ts
@@ -121,9 +121,22 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
         timestamp: new Date(),
         status: MessageStatus.ERROR,
       };
+      // Clean up the optimistic assistant placeholder created by
+      // START_GENERATION so a failed send renders as a single error row
+      // rather than "empty assistant bubble + error". If the assistant had
+      // already streamed partial text before the failure, keep the content
+      // (marking it COMPLETE so the spinner stops) -- only drop truly empty
+      // placeholders.
+      const cleaned = state.messages.flatMap(msg => {
+        if (msg.role !== MessageRole.ASSISTANT || msg.status !== MessageStatus.STREAMING) {
+          return [msg];
+        }
+        if (msg.content === '') return [];
+        return [{ ...msg, status: MessageStatus.COMPLETE }];
+      });
       return {
         ...state,
-        messages: [...state.messages, errorMessage],
+        messages: [...cleaned, errorMessage],
         isGenerating: false,
         currentResponseId: null,
       };


### PR DESCRIPTION
Closes #33.

## Summary

Two related bugs, both surfaced in #33:

1. **False `(cancelled)` after ~30s of streaming.** `JsonRpcClient` applied its 30s default timeout to *every* request, including `session/prompt` — which is a long-running, streaming ACP method that can run for minutes (reasoning, tool calls, etc.). When the timer fired mid-stream the extension posted `createGenerationCancelledMessage` to the webview, the UI rendered `(cancelled)`, and `currentResponseId` was nulled so subsequent `session/update` chunks were silently dropped — even though goose kept generating and eventually returned `stopReason: end_turn`.
2. **`-32000 Client disposed` after `Goose: Restart`.** `setupAcpCommunication` captured the `JsonRpcClient` in a closure once during `activate()`. On restart, `SubprocessManager` disposes the old client and creates a new one, but the closure kept calling the disposed reference — every post-restart send failed with `Client disposed`.

## Changes

- `src/extension/jsonRpcClient.ts` — `request()` now takes an optional third `options?: { timeoutMs?: number | null }` argument. `null` disables the timer entirely; a `number` overrides the default; omitting it preserves existing behaviour. `PendingRequestEntry.timer` is now optional and all `clearTimeout` sites are guarded.
- `src/extension/extension.ts` — `session/prompt` is issued with `{ timeoutMs: null }`. `setupAcpCommunication` is refactored to take the `SubprocessManager` and resolve the live client via `getClient()` on every `request`/`notify`. The `session/update` listener is re-attached on each `ProcessStatus.RUNNING` transition, guarded with a `lastSubscribedClient` ref to avoid double-subscribing on initial activation.
- `src/extension/jsonRpcClient.test.ts` — new unit test verifying `request(..., { timeoutMs: null })` does not time out when a response is delivered after the default timeout window.

## Test plan

- [x] `bun test` — 233/233 pass (1 new test added)
- [x] `bunx biome ci` — clean on touched files
- [x] `bun run build` — extension + webview + tailwind all bundle clean
- [x] Manual: long streaming prompt (> 30s) — reply finishes normally, no `(cancelled)` badge
- [x] Manual: `Goose: Restart`, then send a message — reply streams from the new subprocess (no `Client disposed`)
- [x] Manual: short prompt still completes quickly and still shows the `stopReason: end_turn` log line

## Notes

- Out of scope — there's pre-existing `tsc --noEmit` noise in `jsonRpcClient.test.ts` (missing `bun:test` typings, stale `Logger` mock shape, un-narrowed discriminated-union accesses on old tests). Not touched here.
- PR #39 independently lands the same `timeoutMs: null` fix bundled inside a much larger feature PR. This PR is the minimal targeted fix for #33 alone; the two are not mutually exclusive.