### PR TITLE
Avoid macOS Goose desktop binary auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See Goose think in real-time. Responses stream token-by-token with syntax-highli
 ## Requirements
 
 - **VS Code 1.95.0+**
-- **Goose Desktop 1.16.0+** — [Install Goose](https://block.github.io/goose/)
+- **Goose CLI 1.16.0+** — [Install Goose](https://block.github.io/goose/) and ensure `goose --version` works from your command line.
 
 ## Installation
 

--- a/src/extension/binaryDiscovery.test.ts
+++ b/src/extension/binaryDiscovery.test.ts
@@ -225,10 +225,10 @@ describe('binaryDiscovery', () => {
 
     describe('darwin platform', () => {
       test('searches darwin-specific paths', () => {
-        addExistingPath('/Applications/Goose.app/Contents/MacOS/goose');
+        addExistingPath('/usr/local/bin/goose');
 
         const result = findInPlatformPaths('darwin', homeDir, env);
-        expect(result).toBe('/Applications/Goose.app/Contents/MacOS/goose');
+        expect(result).toBe('/usr/local/bin/goose');
       });
 
       test('returns first found path in priority order', () => {
@@ -236,8 +236,6 @@ describe('binaryDiscovery', () => {
         addExistingPath('/usr/local/bin/goose');
 
         const result = findInPlatformPaths('darwin', homeDir, env);
-        // ~/.local/bin comes after /Applications/Goose.app in darwin paths
-        // So if only these two exist, it should return the first in the list
         expect(result).toBe('/home/testuser/.local/bin/goose');
       });
 
@@ -320,7 +318,7 @@ describe('binaryDiscovery', () => {
           homeDir,
         };
         addExistingPath('/custom/path/goose');
-        addExistingPath('/Applications/Goose.app/Contents/MacOS/goose');
+        addExistingPath('/home/testuser/.local/bin/goose');
 
         const result = discoverBinary(config);
         expect(E.isRight(result)).toBe(true);
@@ -337,7 +335,7 @@ describe('binaryDiscovery', () => {
           homeDir,
         };
         addExistingPath('/usr/local/bin/goose');
-        addExistingPath('/Applications/Goose.app/Contents/MacOS/goose');
+        addExistingPath('/home/testuser/.local/bin/goose');
 
         const result = discoverBinary(config);
         expect(E.isRight(result)).toBe(true);
@@ -353,12 +351,12 @@ describe('binaryDiscovery', () => {
           env: { ...env, PATH: '' },
           homeDir,
         };
-        addExistingPath('/Applications/Goose.app/Contents/MacOS/goose');
+        addExistingPath('/home/testuser/.local/bin/goose');
 
         const result = discoverBinary(config);
         expect(E.isRight(result)).toBe(true);
         if (E.isRight(result)) {
-          expect(result.right).toBe('/Applications/Goose.app/Contents/MacOS/goose');
+          expect(result.right).toBe('/home/testuser/.local/bin/goose');
         }
       });
 
@@ -505,13 +503,26 @@ describe('binaryDiscovery', () => {
           env: {},
           homeDir,
         };
-        addExistingPath('/Applications/Goose.app/Contents/MacOS/goose');
+        addExistingPath('/usr/local/bin/goose');
 
         const result = discoverBinary(config);
         expect(E.isRight(result)).toBe(true);
         if (E.isRight(result)) {
-          expect(result.right).toBe('/Applications/Goose.app/Contents/MacOS/goose');
+          expect(result.right).toBe('/usr/local/bin/goose');
         }
+      });
+
+      test('does not discover the macOS desktop app executable as a CLI binary', () => {
+        const config: BinaryDiscoveryConfig = {
+          userConfiguredPath: undefined,
+          platform: 'darwin',
+          env: { ...env, PATH: '' },
+          homeDir,
+        };
+        addExistingPath('/Applications/Goose.app/Contents/MacOS/goose');
+
+        const result = discoverBinary(config);
+        expect(E.isLeft(result)).toBe(true);
       });
     });
   });
@@ -550,8 +561,8 @@ describe('binaryDiscovery', () => {
       };
 
       const paths = getAllSearchPaths(config);
-      expect(paths).toContain('/Applications/Goose.app/Contents/MacOS/goose');
       expect(paths).toContain('/home/testuser/.local/bin/goose');
+      expect(paths).toContain('/usr/local/bin/goose');
     });
 
     test('expands tilde in returned paths', () => {

--- a/src/extension/binaryDiscovery.ts
+++ b/src/extension/binaryDiscovery.ts
@@ -15,12 +15,7 @@ import { BinaryDiscoveryConfig } from '../shared/types';
 // ============================================================================
 
 const SEARCH_PATHS: Partial<Record<NodeJS.Platform, readonly string[]>> = {
-  darwin: [
-    '/Applications/Goose.app/Contents/MacOS/goose',
-    '~/.local/bin/goose',
-    '/usr/local/bin/goose',
-    '/opt/homebrew/bin/goose',
-  ],
+  darwin: ['~/.local/bin/goose', '/usr/local/bin/goose', '/opt/homebrew/bin/goose'],
   win32: ['%LOCALAPPDATA%\\Goose\\goose.exe', '%PROGRAMFILES%\\Goose\\goose.exe'],
   linux: [
     '~/.local/bin/goose',


### PR DESCRIPTION
## Summary
- Stop auto-detecting the macOS Goose desktop app executable as the CLI.
- Clarify the README requirement as Goose CLI and add regression coverage.

Fixes #42

## Test
- bun test src/extension/binaryDiscovery.test.ts src/extension/versionChecker.test.ts
- bunx --bun biome check README.md src/extension/binaryDiscovery.ts src/extension/binaryDiscovery.test.ts