### PR TITLE
ci: attach packaged .vsix to releases for manual publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI - Main & Release
 # This workflow handles:
 # 1. Running release-please on pushes to main
 # 2. Running tests on pushes to main
-# 3. Building and publishing releases on tag pushes
+# 3. Packaging a .vsix and uploading it to the GitHub Release when release-please creates one
 
 permissions:
   contents: write # Needed for release job & release-please
@@ -63,35 +63,13 @@ jobs:
 
       - name: Package Extension
         if: steps.release.outputs.release_created
-        run: |
-          mkdir -p dist
-          VERSION="${{ steps.release.outputs.tag_name }}"
-          VERSION="${VERSION#vscode-v}"  # Remove vscode-v prefix
-          PACKAGE_FILENAME="dist/vscode-goose-${VERSION}.vsix"
-          npx @vscode/vsce package --no-yarn --no-dependencies -o "$PACKAGE_FILENAME"
-          if [ ! -f "$PACKAGE_FILENAME" ]; then
-            echo "Failed to create the VSIX package: $PACKAGE_FILENAME"
-            exit 1
-          fi
-          ls -l dist
+        run: bunx @vscode/vsce package --no-dependencies
 
       - name: Upload Release Assets
         if: steps.release.outputs.release_created
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ steps.release.outputs.tag_name }} dist/*.vsix
-
-      - name: Publish to VS Code Marketplace
-        if: steps.release.outputs.release_created && env.VSCE_PAT != null
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: |
-          VERSION="${{ steps.release.outputs.tag_name }}"
-          VERSION="${VERSION#vscode-v}"  # Remove vscode-v prefix
-          PACKAGE_FILENAME="dist/vscode-goose-${VERSION}.vsix"
-          echo "Publishing $PACKAGE_FILENAME to VS Code Marketplace..."
-          npx @vscode/vsce publish --packagePath "$PACKAGE_FILENAME" --pat $VSCE_PAT
+        run: gh release upload "${{ steps.release.outputs.tag_name }}" *.vsix
 
   # This job runs ONLY on pushes to the main branch
   test-on-main:


### PR DESCRIPTION
## Summary
- When release-please creates a release, the release job now packages the extension (`bun install --frozen-lockfile` → `bun run build` → `bunx @vscode/vsce package --no-dependencies`) and uploads the versioned `.vsix` to the GitHub Release via `gh release upload` on the built-in `GITHUB_TOKEN`.
- The **Publish to VS Code Marketplace** step and its `VSCE_PAT` secret are removed — publishing is now done manually by downloading the `.vsix` from the release.
- Fully bun-based: no second lockfile, no npm. Single-file diff to `ci.yml`.
- No new triggers (`push` to main + `workflow_dispatch` only), no new secrets; all steps remain gated on `steps.release.outputs.release_created`.

## Verification
- Workflow YAML validated (parse + step-sequence assertions on the gated block)
- Local dry-run of the exact pipeline: `bun install --frozen-lockfile && bun run build && bunx @vscode/vsce package --no-dependencies` produced `vscode-goose-0.2.1.vsix` (16 files, 13.07 MB) at repo root, matching the `*.vsix` upload glob
- Production precedent: the v0.2.1 release asset was built from bun-installed deps + vsce by the previous workflow, so this dependency path has shipped releases before
- Lockfile-drift guard: `pr-checks.yml` already runs `bun install --frozen-lockfile`, so a stale `bun.lock` fails at PR time, never in the release job (addresses the review finding on pr-47-review-001)

## Notes
- Merge this **before** release PR #43 so the v0.2.2 release job runs the new workflow and carries a `.vsix` asset.
- Asset naming changes from `vscode-goose-v0.2.1.vsix` to `vscode-goose-<version>.vsix` (vsce default from `package.json`) — cosmetic.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)