### PR TITLE
fix: surface ACP error details and prevent blank chat error blocks

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs/promises';
 import * as vscode from 'vscode';
 import {
   formatError,
+  formatErrorDetail,
   isBinaryNotFoundError,
   isSubprocessSpawnError,
   SubprocessSpawnError,
@@ -439,13 +440,14 @@ function setupAcpWebviewHandlers(
           // The webview's ADD_ERROR_MESSAGE reducer cleans up the optimistic
           // assistant placeholder, so we don't need to also post
           // GENERATION_COMPLETE here (which would leave a blank bubble).
+          const body = 'Goose subprocess is not running. Try "Goose: Restart".';
           provider.postMessage(
-            createErrorMessage(
-              'Message Send Failed',
-              'Goose subprocess is not running. Try "Goose: Restart".',
-              { label: 'View Logs', command: 'goose.showLogs' }
-            )
+            createErrorMessage('Message Send Failed', body, {
+              label: 'View Logs',
+              command: 'goose.showLogs',
+            })
           );
+          showErrorToast(body);
           responseIdRef.current = null;
           return;
         }
@@ -469,13 +471,14 @@ function setupAcpWebviewHandlers(
           // placeholder (or marks a partially-streamed one complete) and
           // resets isGenerating. No GENERATION_COMPLETE needed -- sending
           // both would leave a blank bubble above the error row.
+          const body = `Failed to send message: ${formatErrorDetail(result.left)}`;
           provider.postMessage(
-            createErrorMessage(
-              'Message Send Failed',
-              `Failed to send message: ${result.left.message}`,
-              { label: 'View Logs', command: 'goose.showLogs' }
-            )
+            createErrorMessage('Message Send Failed', body, {
+              label: 'View Logs',
+              command: 'goose.showLogs',
+            })
           );
+          showErrorToast(body);
           responseIdRef.current = null;
         } else {
           log.info(`Generation completed with stopReason: ${result.right.stopReason}`);
@@ -525,7 +528,7 @@ function setupAcpWebviewHandlers(
           } else {
             log.error('Failed to create session:', result.left);
             provider.postMessage(
-              createErrorMessage('Session Creation Failed', result.left.message)
+              createErrorMessage('Session Creation Failed', formatErrorDetail(result.left))
             );
           }
         });
@@ -556,7 +559,9 @@ function setupAcpWebviewHandlers(
             log.info(`Session loaded: ${sessionId}`);
           } else {
             log.error('Failed to load session:', result.left);
-            provider.postMessage(createErrorMessage('Session Load Failed', result.left.message));
+            provider.postMessage(
+              createErrorMessage('Session Load Failed', formatErrorDetail(result.left))
+            );
           }
         });
     }
@@ -710,17 +715,17 @@ function setupFileSearchHandler(
   log.debug('File search handler registered');
 }
 
+/** Show an error notification with a "View Logs" action that opens the Goose output channel. */
+function showErrorToast(message: string): void {
+  vscode.window.showErrorMessage(message, 'View Logs').then(selection => {
+    if (selection === 'View Logs') {
+      vscode.commands.executeCommand('goose.showLogs');
+    }
+  });
+}
+
 function showSubprocessError(error: SubprocessSpawnError): void {
-  vscode.window
-    .showErrorMessage(
-      `Failed to start Goose: ${error.code}. Check the Goose output for details.`,
-      'View Logs'
-    )
-    .then(selection => {
-      if (selection === 'View Logs') {
-        vscode.commands.executeCommand('goose.showLogs');
-      }
-    });
+  showErrorToast(`Failed to start Goose: ${error.code}. Check the Goose output for details.`);
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {

--- a/src/shared/errors.test.ts
+++ b/src/shared/errors.test.ts
@@ -8,6 +8,7 @@ import {
   createSubprocessSpawnError,
   createVersionMismatchError,
   formatError,
+  formatErrorDetail,
 } from './errors';
 
 describe('formatError', () => {
@@ -156,5 +157,46 @@ describe('formatError', () => {
       expect(formatted).toContain('https://');
       expect(formatted).toContain('updating-goose');
     });
+  });
+});
+
+describe('formatErrorDetail', () => {
+  test('appends string data to the message', () => {
+    const error = createJsonRpcError(-32603, 'Internal error', 'Missing provider');
+
+    expect(formatErrorDetail(error)).toBe('Internal error — Missing provider');
+  });
+
+  test('appends object data as compact JSON', () => {
+    const error = createJsonRpcError(-32603, 'Internal error', { reason: 'no provider' });
+
+    expect(formatErrorDetail(error)).toBe('Internal error — {"reason":"no provider"}');
+  });
+
+  test('returns message unchanged when data is undefined', () => {
+    const error = createJsonRpcError(-32603, 'Internal error');
+
+    expect(formatErrorDetail(error)).toBe('Internal error');
+  });
+
+  test('returns message unchanged when data is null or blank', () => {
+    expect(formatErrorDetail(createJsonRpcError(-32603, 'Internal error', null))).toBe(
+      'Internal error'
+    );
+    expect(formatErrorDetail(createJsonRpcError(-32603, 'Internal error', '   '))).toBe(
+      'Internal error'
+    );
+  });
+
+  test('returns message unchanged for non-JsonRpc errors', () => {
+    const error = createJsonRpcTimeoutError('session/prompt', 30000, 42);
+
+    expect(formatErrorDetail(error)).toBe(error.message);
+  });
+
+  test('truncates long data to 200 characters with ellipsis', () => {
+    const error = createJsonRpcError(-32603, 'Internal error', 'x'.repeat(300));
+
+    expect(formatErrorDetail(error)).toBe(`Internal error — ${'x'.repeat(200)}…`);
   });
 });

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -277,3 +277,34 @@ export function formatError(error: GooseError): string {
       );
   }
 }
+
+const MAX_ERROR_DETAIL_LENGTH = 200;
+
+function stringifyErrorData(data: unknown): string {
+  if (typeof data === 'string') return data;
+  try {
+    return JSON.stringify(data) ?? '';
+  } catch {
+    return String(data);
+  }
+}
+
+/**
+ * Format an error's user-facing message, enriched with the JSON-RPC `error.data`
+ * detail when present (e.g. "Internal error — Missing provider").
+ * Non-JsonRpc errors and absent/blank data return the message unchanged.
+ */
+export function formatErrorDetail(error: GooseError): string {
+  if (!isJsonRpcError(error) || error.data === undefined || error.data === null) {
+    return error.message;
+  }
+  const detail = stringifyErrorData(error.data).trim();
+  if (detail === '') {
+    return error.message;
+  }
+  const truncated =
+    detail.length > MAX_ERROR_DETAIL_LENGTH
+      ? `${detail.slice(0, MAX_ERROR_DETAIL_LENGTH)}…`
+      : detail;
+  return `${error.message} — ${truncated}`;
+}

--- a/src/shared/messages.test.ts
+++ b/src/shared/messages.test.ts
@@ -137,7 +137,11 @@ describe('buildErrorBlockContent', () => {
   });
 
   test('returns static fallback when both title and message are blank', () => {
-    expect(buildErrorBlockContent({ title: '', message: '' })).toBe('Something went wrong');
-    expect(buildErrorBlockContent({ title: '  ', message: ' ' })).toBe('Something went wrong');
+    expect(buildErrorBlockContent({ title: '', message: '' })).toBe(
+      'Something went wrong. Check the Goose output log for details.'
+    );
+    expect(buildErrorBlockContent({ title: '  ', message: ' ' })).toBe(
+      'Something went wrong. Check the Goose output log for details.'
+    );
   });
 });

--- a/src/shared/messages.test.ts
+++ b/src/shared/messages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  buildErrorBlockContent,
   isSendMessageMessage,
   isStatusUpdateMessage,
   isVersionStatusMessage,
@@ -102,5 +103,41 @@ describe('isVersionStatusMessage', () => {
 
   test('returns false for malformed object', () => {
     expect(isVersionStatusMessage({ wrongField: 'value' })).toBe(false);
+  });
+});
+
+describe('buildErrorBlockContent', () => {
+  test('joins title and message with a colon', () => {
+    const content = buildErrorBlockContent({
+      title: 'Message Send Failed',
+      message: 'Failed to send message: Internal error — Missing provider',
+    });
+
+    expect(content).toBe(
+      'Message Send Failed: Failed to send message: Internal error — Missing provider'
+    );
+  });
+
+  test('returns title when message is empty', () => {
+    expect(buildErrorBlockContent({ title: 'Message Send Failed', message: '' })).toBe(
+      'Message Send Failed'
+    );
+  });
+
+  test('returns title when message is whitespace', () => {
+    expect(buildErrorBlockContent({ title: 'Message Send Failed', message: '   ' })).toBe(
+      'Message Send Failed'
+    );
+  });
+
+  test('returns message when title is empty', () => {
+    expect(buildErrorBlockContent({ title: '', message: 'Something failed' })).toBe(
+      'Something failed'
+    );
+  });
+
+  test('returns static fallback when both title and message are blank', () => {
+    expect(buildErrorBlockContent({ title: '', message: '' })).toBe('Something went wrong');
+    expect(buildErrorBlockContent({ title: '  ', message: ' ' })).toBe('Something went wrong');
   });
 });

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -92,7 +92,8 @@ export interface ErrorPayload {
   };
 }
 
-const FALLBACK_ERROR_BLOCK_CONTENT = 'Something went wrong';
+export const FALLBACK_ERROR_BLOCK_CONTENT =
+  'Something went wrong. Check the Goose output log for details.';
 
 /**
  * Build the chat error-block text for an ERROR payload.

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -92,6 +92,22 @@ export interface ErrorPayload {
   };
 }
 
+const FALLBACK_ERROR_BLOCK_CONTENT = 'Something went wrong';
+
+/**
+ * Build the chat error-block text for an ERROR payload.
+ * Never returns an empty string: falls back to title, message, or a static
+ * fallback so the error block always renders visible text.
+ */
+export function buildErrorBlockContent(payload: ErrorPayload): string {
+  const title = payload.title.trim();
+  const message = payload.message.trim();
+  if (title && message) return `${title}: ${message}`;
+  if (title) return title;
+  if (message) return message;
+  return FALLBACK_ERROR_BLOCK_CONTENT;
+}
+
 /** Payload for SEND_MESSAGE message */
 export interface SendMessagePayload {
   readonly content: string;

--- a/src/webview/components/chat/ErrorMessage.tsx
+++ b/src/webview/components/chat/ErrorMessage.tsx
@@ -1,11 +1,11 @@
+import { FALLBACK_ERROR_BLOCK_CONTENT } from '../../../shared/messages';
+
 interface ErrorMessageProps {
   content: string;
   timestamp?: Date;
   onRetry?: (content: string) => void;
   originalContent?: string;
 }
-
-const FALLBACK_ERROR_TEXT = 'Something went wrong. Check the Goose output log for details.';
 
 function formatTime(date?: Date): string {
   if (!date) return 'Earlier';
@@ -14,7 +14,7 @@ function formatTime(date?: Date): string {
 
 export function ErrorMessage({ content, timestamp, onRetry, originalContent }: ErrorMessageProps) {
   const canRetry = onRetry && originalContent;
-  const displayContent = content.trim() ? content : FALLBACK_ERROR_TEXT;
+  const displayContent = content.trim() ? content : FALLBACK_ERROR_BLOCK_CONTENT;
 
   return (
     <div className="flex flex-col items-start">

--- a/src/webview/components/chat/ErrorMessage.tsx
+++ b/src/webview/components/chat/ErrorMessage.tsx
@@ -5,6 +5,8 @@ interface ErrorMessageProps {
   originalContent?: string;
 }
 
+const FALLBACK_ERROR_TEXT = 'Something went wrong. Check the Goose output log for details.';
+
 function formatTime(date?: Date): string {
   if (!date) return 'Earlier';
   return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
@@ -12,6 +14,7 @@ function formatTime(date?: Date): string {
 
 export function ErrorMessage({ content, timestamp, onRetry, originalContent }: ErrorMessageProps) {
   const canRetry = onRetry && originalContent;
+  const displayContent = content.trim() ? content : FALLBACK_ERROR_TEXT;
 
   return (
     <div className="flex flex-col items-start">
@@ -19,7 +22,7 @@ export function ErrorMessage({ content, timestamp, onRetry, originalContent }: E
         <div className="flex items-start gap-2">
           <ErrorIcon className="w-4 h-4 text-[var(--vscode-errorForeground)] shrink-0 mt-0.5" />
           <div className="flex-1 min-w-0">
-            <p className="text-[var(--vscode-errorForeground)] text-sm">{content}</p>
+            <p className="text-[var(--vscode-errorForeground)] text-sm">{displayContent}</p>
             {canRetry && (
               <button
                 onClick={() => onRetry(originalContent)}

--- a/src/webview/components/chat/ErrorMessage.tsx
+++ b/src/webview/components/chat/ErrorMessage.tsx
@@ -20,9 +20,11 @@ export function ErrorMessage({ content, timestamp, onRetry, originalContent }: E
     <div className="flex flex-col items-start">
       <div className="w-full p-3 bg-[var(--vscode-inputValidation-errorBackground,rgba(255,0,0,0.1))] border border-[var(--vscode-inputValidation-errorBorder,var(--vscode-errorForeground))] rounded-lg">
         <div className="flex items-start gap-2">
-          <ErrorIcon className="w-4 h-4 text-[var(--vscode-errorForeground)] shrink-0 mt-0.5" />
+          <ErrorIcon className="w-4 h-4 text-[var(--vscode-inputValidation-errorForeground,var(--vscode-foreground))] shrink-0 mt-0.5" />
           <div className="flex-1 min-w-0">
-            <p className="text-[var(--vscode-errorForeground)] text-sm">{displayContent}</p>
+            <p className="text-[var(--vscode-inputValidation-errorForeground,var(--vscode-foreground))] text-sm">
+              {displayContent}
+            </p>
             {canRetry && (
               <button
                 onClick={() => onRetry(originalContent)}

--- a/src/webview/hooks/useChat.ts
+++ b/src/webview/hooks/useChat.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useReducer, useRef } from 'react';
 import type { ContextChip } from '../../shared/contextTypes';
 import {
+  buildErrorBlockContent,
   ContextChipData,
   createSendMessageMessage,
   createStopGenerationMessage,
@@ -236,12 +237,11 @@ export function useChat(): UseChatReturn {
       } else if (isSessionCreatedMessage(message)) {
         dispatch({ type: 'CLEAR_MESSAGES' });
       } else if (isErrorMessage(message)) {
-        const { title, message: body } = message.payload;
         dispatch({
           type: 'ADD_ERROR_MESSAGE',
           payload: {
             id: generateId(),
-            content: body ? `${title}: ${body}` : title,
+            content: buildErrorBlockContent(message.payload),
           },
         });
       }


### PR DESCRIPTION
## Summary
Found during manual testing of v0.2.2: a failed message send rendered an **empty pink error block**, while the actionable JSON-RPC detail (`error.data: "Missing provider"`) was logged but never shown — the UI only said "Internal error".

- `formatErrorDetail()` enriches user-facing messages with `JsonRpcError.data` → "Internal error — Missing provider" (object data JSON-compacted, 200-char cap, never throws); applied at the send, session-create, and session-load failure sites
- `buildErrorBlockContent()` guarantees chat error blocks can never render empty, with a defensive fallback in `ErrorMessage.tsx`
- Send failures now also raise an error toast with a working **View Logs** action

## Verification
- 246/246 tests (11 new, TDD red→green), biome clean, build clean
- The original bug scenario replayed headlessly: `createJsonRpcError(-32603, 'Internal error', 'Missing provider')` renders "Failed to send message: Internal error — Missing provider" in both block and toast

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)