### PR TITLE
fix(shared): truncate Windows paths correctly

### DIFF
--- a/src/shared/sessionTypes.test.ts
+++ b/src/shared/sessionTypes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { truncatePath } from './sessionTypes';
+
+describe('truncatePath', () => {
+  test('returns paths within the max length unchanged', () => {
+    const path = 'C:\\Users\\prem\\file.ts';
+
+    expect(truncatePath(path, 100)).toBe(path);
+  });
+
+  test('truncates Unix paths with forward slash separators', () => {
+    expect(
+      truncatePath('/Users/prem/Development/vscode-goose/src/shared/sessionTypes.ts', 30)
+    ).toBe('.../shared/sessionTypes.ts');
+  });
+
+  test('truncates Windows paths with backslash separators', () => {
+    expect(
+      truncatePath('C:\\Users\\prem\\Development\\vscode-goose\\src\\shared\\sessionTypes.ts', 30)
+    ).toBe('...\\shared\\sessionTypes.ts');
+  });
+});

--- a/src/shared/sessionTypes.ts
+++ b/src/shared/sessionTypes.ts
@@ -125,8 +125,12 @@ export function formatSessionTime(createdAt: string): string {
 export function truncatePath(path: string, maxLength: number = 30): string {
   if (path.length <= maxLength) return path;
 
-  const parts = path.split('/').filter(Boolean);
-  if (parts.length <= 2) return '.../' + parts.join('/');
+  const lastForwardSlash = path.lastIndexOf('/');
+  const lastBackslash = path.lastIndexOf('\\');
+  const separator = lastBackslash > lastForwardSlash ? '\\' : '/';
+  const parts = path.split(/[/\\]/).filter(Boolean);
 
-  return '.../' + parts.slice(-2).join('/');
+  if (parts.length <= 2) return '...' + separator + parts.join(separator);
+
+  return '...' + separator + parts.slice(-2).join(separator);
 }


### PR DESCRIPTION
## Summary
- update `truncatePath` to split display paths on both Unix and Windows separators
- keep the truncated output separator consistent with the input path
- add unit coverage for unchanged short paths, Unix paths, and Windows backslash paths

Fixes #55.

## Why
`truncatePath` previously split only on `/`, so backslash-only Windows paths were treated as one segment and displayed almost unmodified with a mixed `.../C:\...` prefix. This keeps the existing Unix behavior while making Windows session paths truncate to the final path components as intended.

## Verification
- `npm exec --yes bun@latest -- test src/shared/sessionTypes.test.ts`
- `npm exec --yes bun@latest -- test src/shared`
- `./node_modules/.bin/biome check src/shared/sessionTypes.ts src/shared/sessionTypes.test.ts`
- `npm exec --yes bun@latest -- test`
- `npm exec --yes bun@latest -- run build`
